### PR TITLE
Change 301 to 302 in middleware example

### DIFF
--- a/src/shared/en/aws/guides-middleware.md
+++ b/src/shared/en/aws/guides-middleware.md
@@ -33,7 +33,7 @@ async function requireLogin(request) {
 	if (!state.isLoggedIn) {
 		console.log(`Attempt to access dashboard without logging in!`);
     return {
-      status: 301,
+      status: 302,
       location: `/login`
     };
 	}


### PR DESCRIPTION
Chrome caches 301 redirects which can lead to very confusing middleware route debugging, in addition to which a hard site refresh in incognito mode doesn't clear the 301 cache...