### PR TITLE
Fixing broken links

### DIFF
--- a/public/guides/dns.md
+++ b/public/guides/dns.md
@@ -7,7 +7,7 @@ DNS is how you assign a domain name to a deployed app. This guide lists ways to 
 
 ## Setting up `.arc` with a custom domain name
 
-`arc` has built-in first-class support for setting up DNS and assigning a domain. First add [`@domain`](/reference/domain) to your `.arc` file with a value of the domain name you wish to set up.
+`arc` has built-in first-class support for setting up DNS and assigning a domain. First add [`@domain`]('#null') to your `.arc` file with a value of the domain name you wish to set up.
 
 ```arc
 @app
@@ -75,7 +75,7 @@ If you _really_ want to manually configure DNS you can follow these guides below
 
 ## Route 53
 
-Follow these instructions to manually configure Route 53 to serve your application from your domain. As a friendly reminder: the `arc` happy path for using Route 53 remains the [`@domain`](/reference/domain) section (per the instructions above).
+Follow these instructions to manually configure Route 53 to serve your application from your domain. As a friendly reminder: the `arc` happy path for using Route 53 remains the [`@domain`](#null) section (per the instructions above).
 
 > ⛳️ Tip: These instructions will serve your app's production environment; if you'd also like a friendly URL for your staging environment (i.e. `staging.foo.com`), follow steps 10-15 below a second time, swapping `production` values for `staging` values.
 

--- a/public/guides/logs.md
+++ b/public/guides/logs.md
@@ -25,5 +25,5 @@ To clear the logs run `npx logs nuke`.
 
 <hr>
 
-## Next: [Assigning a Custom Domain Name](/guides/custom-dns)
+## Next: [Assigning a Custom Domain Name](#null)
 

--- a/public/guides/project-manifest.md
+++ b/public/guides/project-manifest.md
@@ -39,28 +39,28 @@ The `.arc` manifest can be broadly split into three conceptual classifications o
 
 These pragmas are for global and cloud-vendor configuration, the most important of which being the `@app` namespace (which is used to prefix and identify all generated resources).
 
-- [`@app`](/reference/app) - **[Required]** The application namespace
-- [`@aws`](/reference/aws) - AWS-specific config (also includes global runtime setting)
+- [`@app`](/reference/arc/app) - **[Required]** The application namespace
+- [`@aws`](/reference/arc/aws) - AWS-specific config (also includes global runtime setting)
 
 
 ### 2. Functions
 
 These pragmas deal with cloud functions (i.e. Lambdas); function pragmas are always reflective of a single event source (i.e. `@http` functions are invoked by HTTP events; `@events` functions are invoked by events to the event bus).
 
-- [`@http`](/reference/http) - HTTP routes (API Gateway)
-- [`@events`](/reference/events) - Event pub/sub (SNS)
-- [`@queues`](/reference/queues) - Queues & queue handlers (SQS)
-- [`@scheduled`](/reference/scheduled) - Invoke functions on specified schedules (CloudWatch Events)
-- [`@ws`](/reference/ws) - WebSocket functions (API Gateway)
+- [`@http`](/reference/arc/http) - HTTP routes (API Gateway)
+- [`@events`](/reference/arc/events) - Event pub/sub (SNS)
+- [`@queues`](/reference/arc/queues) - Queues & queue handlers (SQS)
+- [`@scheduled`](/reference/arc/scheduled) - Invoke functions on specified schedules (CloudWatch Events)
+- [`@ws`](/reference/arc/ws) - WebSocket functions (API Gateway)
 
 
 ### 3. Persistence
 
 These pragmas specify various persistence resources.
 
-- [`@static`](/reference/static) - Buckets for hosting static assets (S3)
-- [`@tables`](/reference/tables) - Database tables & trigger functions (DynamoDB)
-- [`@indexes`](/reference/indexes) - Table global secondary indexes (DynamoDB)
+- [`@static`](/reference/arc/static) - Buckets for hosting static assets (S3)
+- [`@tables`](/reference/arc/tables) - Database tables & trigger functions (DynamoDB)
+- [`@indexes`](/reference/arc/indexes) - Table global secondary indexes (DynamoDB)
 
 
 ## Example

--- a/public/guides/sessions.md
+++ b/public/guides/sessions.md
@@ -86,7 +86,7 @@ This will sync all production lambdas to use the DynamoDB table while testing an
 - Error messages
 - Shopping carts
 
-See [the sessions reference](/reference/http-session) for more details.
+See [the sessions reference](#null) for more details.
 
 <hr>
 

--- a/public/intro/limits.md
+++ b/public/intro/limits.md
@@ -28,7 +28,7 @@ Architect primitives are based on the following AWS serverless ecosystem service
 ## Cloud limits and gotchas
 
 - Lambda cold starts are vicious on large Lambdas; the best antidote is to author small as possible Lambda functions (rule of thumb: sub 5MB compressed, including modules, usually results in sub-second execution)
-- Lambda functions are time-limited to 5 seconds [by default](/reference/arc-config). This can be [adjusted](/reference/arc-config), however they cannot execute for longer than 15 minutes maximum. You can also use [background tasks](/guides/background-tasks) to break work down into smaller chunks.
+- Lambda functions are time-limited to 5 seconds [by default](/reference/arc-config/aws). This can be [adjusted](/reference/arc-config/aws), however they cannot execute for longer than 15 minutes maximum. You can also use [background tasks](/guides/background-tasks) to break work down into smaller chunks.
 - CloudFormation templates can only have 200 resources; Architect can nest templates but API Gateway can only support 300 routes and many other limits can apply
 
 ---

--- a/public/intro/philosophy.md
+++ b/public/intro/philosophy.md
@@ -27,15 +27,15 @@ The `.arc` format follows a few simple rules:
 
 `.arc` files are made up of the following sections:
 
-- [`@app`](/reference/app) [*required*] defines your application namespace
-- [`@aws`](/reference/aws) defines AWS variables
-- [`@events`](/reference/events) defines application events you can publish and subscribe to
-- [`@http`](/reference/http) defines HTTP (i.e. `text/html`) handlers
-- [`@indexes`](/reference/indexes) defines table global secondary indexes
-- [`@scheduled`](/reference/scheduled) defines functions that run on a schedule
-- [`@static`](/reference/static) defines S3 buckets for static assets
-- [`@tables`](/reference/tables) defines DynamoDB database tables and trigger functions for them
-- [`@ws`](/reference/ws) defines WebSocket handlers
+- [`@app`](/reference/arc/app) [*required*] defines your application namespace
+- [`@aws`](/reference/arc/aws) defines AWS variables
+- [`@events`](/reference/arc/events) defines application events you can publish and subscribe to
+- [`@http`](/reference/arc/http) defines HTTP (i.e. `text/html`) handlers
+- [`@indexes`](/reference/arc/indexes) defines table global secondary indexes
+- [`@scheduled`](/reference/arc/scheduled) defines functions that run on a schedule
+- [`@static`](/reference/arc/static) defines S3 buckets for static assets
+- [`@tables`](/reference/arc/tables) defines DynamoDB database tables and trigger functions for them
+- [`@ws`](/reference/arc/ws) defines WebSocket handlers
 
 This is a complete `.arc` file example:
 

--- a/public/reference/arc-config/index.md
+++ b/public/reference/arc-config/index.md
@@ -24,4 +24,4 @@ policies {ARN}
 
 ---
 
-## Next: [Setup AWS region & profile with `@aws`](/reference/aws)
+## Next: [Setup AWS region & profile with `@aws`](/reference/arc/aws)

--- a/public/reference/arc/app.md
+++ b/public/reference/arc/app.md
@@ -18,5 +18,5 @@ foobaz
 
 ---
 
-## Next: [Setup AWS region & profile with `@aws`](/reference/aws)
+## Next: [Setup AWS region & profile with `@aws`](/reference/arc/aws)
 

--- a/public/reference/arc/events.md
+++ b/public/reference/arc/events.md
@@ -34,5 +34,5 @@ Which generates the corresponding code:
 
 ---
 
-## Next: [Defining routes with `@http`](/reference/http)
+## Next: [Defining routes with `@http`](/reference/arc/http)
 

--- a/public/reference/arc/http.md
+++ b/public/reference/arc/http.md
@@ -49,5 +49,5 @@ Note: The route `/pages/:dateID` corresponding handler deliberately looks a bit 
 
 ---
 
-## Next: [`Creating table indexes with @indexes`](/reference/indexes)
+## Next: [`Creating table indexes with @indexes`](/reference/arc/indexes)
 

--- a/public/reference/arc/indexes.md
+++ b/public/reference/arc/indexes.md
@@ -35,5 +35,5 @@ DynamoDB is a powerful database. There is a great deal more to learn to take ful
 
 ---
 
-## Next: [Creating SQS queues with `@queues`](/reference/queues)
+## Next: [Creating SQS queues with `@queues`](/reference/arc/queues)
 

--- a/public/reference/arc/queues.md
+++ b/public/reference/arc/queues.md
@@ -36,5 +36,5 @@ Which generates the corresponding code:
 
 ---
 
-## Next: [Scheduling functions with `@scheduled`](/reference/scheduled)
+## Next: [Scheduling functions with `@scheduled`](/reference/arc/scheduled)
 

--- a/public/reference/arc/scheduled.md
+++ b/public/reference/arc/scheduled.md
@@ -34,4 +34,4 @@ Which generates the following code:
 └── package.json
 ```
 ---
-## Next: [Creating `@static` asset buckets](/reference/static)
+## Next: [Creating `@static` asset buckets](/reference/arc/static)

--- a/public/reference/arc/static.md
+++ b/public/reference/arc/static.md
@@ -67,4 +67,4 @@ get /
 Running `arc deploy` will serialize `public/` into `sam.json`.
 
 ---
-## Next: [Create dynamo tables with `@tables`](/reference/tables)
+## Next: [Create dynamo tables with `@tables`](/reference/arc/tables)

--- a/public/reference/arc/tables.md
+++ b/public/reference/arc/tables.md
@@ -39,5 +39,5 @@ cats
 ```
 
 
-## Next: [WebSockets with `@ws`](/reference/ws)
+## Next: [WebSockets with `@ws`](/reference/arc/ws)
 

--- a/public/reference/functions/tables/node.md
+++ b/public/reference/functions/tables/node.md
@@ -67,7 +67,7 @@ The generated data layer also allows direct access to DynamoDB through a few met
 - `data._doc` returns an instance of [`AWS.DynamoDB.DocumentClient`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html)
 - `data._name` helper function that returns a completely resolved resource name which is useful for constructing queries to tables or indexes
 
-## Next: [`data._name`](/reference/data-name)
+## Next: [`data._name`](#null)
 # <a id=data.db href=#data.db>`data._db`</a>
 
 ## Get an instance of `AWS.DynamoDB` from the `aws-sdk`
@@ -269,7 +269,7 @@ async function handler(req, res) {
 exports.handler = arc.http(handler)
 ```
 
-## Next: [`put`](/reference/data-put)
+## Next: [`put`](#null)
 
 
 # <a id=data.get href=#data.get>`data.tablename.put`</a>


### PR DESCRIPTION
Noticed some pages aren't linked right. Might be worth checking your Google Search Console for other links that are misdirected.

In cases where I couldn't locate a page to link to I replaced with "#null" you may want to remove the link entirely.