### PR TITLE
updating link to docs about sharing code

### DIFF
--- a/public/guides/local-dev.md
+++ b/public/guides/local-dev.md
@@ -193,5 +193,5 @@ test('arc.sandbox.db.close', t=>{
 ---
 
 
-## Next: [Sharing Common Code Between Functions](/guides/sharing-common-code)
+## Next: [Sharing Common Code Between Functions](/guides/share-code)
 

--- a/public/reference/functions/http/node/async.md
+++ b/public/reference/functions/http/node/async.md
@@ -81,7 +81,7 @@ exports.handler = arc.http.async(addCountryCode, requireLogin, showDashboard)
 
 Super clean!
 
-The `arc.http.async` API works well with [the `shared` folder](/guides/sharing-common-code) to do things like re-use `requireLogin` to protect multiple HTTP functions.
+The `arc.http.async` API works well with [the `shared` folder](/guides/share-code) to do things like re-use `requireLogin` to protect multiple HTTP functions.
 
 Like normal [Architect routes](/guides/http), `arc.http.async` routes also support the AWS [`context`](https://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-context.html) object. `context` will be passed on as a second option to each route.
 


### PR DESCRIPTION
This PR fixes the outdated links to the article about sharing code, currently they all lead to a 404 as the file seems to have been renamed to `share-code.md`