### PR TITLE
remove link to static assets from code-sharing guide

### DIFF
--- a/public/guides/share-code.md
+++ b/public/guides/share-code.md
@@ -89,8 +89,3 @@ exports.handler = async function http(req) {
 Anytime you preview locally, run tests, or deploy the layout, your shared modules get updated.
 
 > Caution! Since `src/shared` gets copied recursively into all Lambdas' node_modules we strongly suggest keeping the directory structure as flat as possible, and the payloads as small possible, so as not bloat your Lambda functions and suffer worse cold starts.
-
----
-
-
-## Next: [Static Assets](/guides/static-assets)


### PR DESCRIPTION
there is no more static asset "guide" (rather, it is an "app primitive" document now), so lets keep the "next" links at the bottom of the "guide" documents only linking to other "guide" documents.

this fixes #237 
