### PR TITLE
How to check Architect version (`arc version`) 

### DIFF
--- a/public/quickstart/install.md
+++ b/public/quickstart/install.md
@@ -32,6 +32,12 @@ arc sandbox
 arc deploy
 ```
 
+### Check Architect version
+
+```bash
+arc version
+```
+
 Congrats, you've successfully created a powerful, modern, serverless app! Nice work. 💖
 
 ---


### PR DESCRIPTION
Added line about how to check Architect version (`arc version`) to Quickstart.