### PR TITLE
variety of db primitive article updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -107,7 +107,7 @@
     },
     "@architect/http-proxy": {
       "version": "3.12.3",
-      "resolved": "https://npm.pkg.github.com/download/@architect/http-proxy/3.12.3/8075447666b76f9b0ed70ec44451ece436f00a47146a10d2e56fdddb6426542f",
+      "resolved": "https://registry.npmjs.org/@architect/http-proxy/-/http-proxy-3.12.3.tgz",
       "integrity": "sha512-NuNehsNC+bvyGhftOKUvSW1mSK87wHAfoHGL9JelDBK8uRc+IafL8rvQceIw3G0E/ziI2YUwUgTgE8f27DpgcQ==",
       "dev": true
     },


### PR DESCRIPTION
- link to core components aws docs
- remove no-longer-existing REPL section
- split out table and index definition into dedicated sections
- update terminology used for keys (partition/sort)
- link to full arc/functions tables reference
- link to ddb stream error handling section.