### PR TITLE
feat: Using TypeScript guide

### DIFF
--- a/src/views/docs/en/guides/developer-experience/using-typescript.md
+++ b/src/views/docs/en/guides/developer-experience/using-typescript.md
@@ -1,0 +1,17 @@
+---
+title: Using TypeScript
+category: Developer experience
+description: How to use Architect with TypeScript
+---
+
+Architect and TypeScript work great together. Types are available in the [@types/architect\_\_functions](https://www.npmjs.com/package/@types/architect__functions) package. Write functions in TypeScript and just be sure to build your functions with TypeScript (`tsc`) before running or deploying. For example, your `package.json` might have the following scripts to build the TypeScript code before deploying and running in the [sandbox for local development](/docs/en/guides/developer-experience/local-development):
+
+```json
+"scripts": {
+  "start": "arc sandbox",
+  "prestart": "npm run build",
+  "deploy": "arc deploy",
+  "predeploy": "npm run build",
+  "build": "tsc"
+}
+```

--- a/src/views/docs/table-of-contents.js
+++ b/src/views/docs/table-of-contents.js
@@ -12,6 +12,7 @@ let Guides = [ {
     'Custom source paths',
     'Deployment',
     'Logging & monitoring', // cloudwatch
+    'Using TypeScript',
   ],
   'Frontend': [
     'Static assets', // fingerprint, ignore, folder, link to cdn


### PR DESCRIPTION
@brianleroux per our discussion in slack. I consider this a draft and am looking for feedback to improve it.
Couple things:

- I put simple but I think clear TypeScript example at https://github.com/activescott/arc-example-typescript and if thought it might be ideal to get that under https://github.com/architect-examples. Then we could reference it from this doc. 
- `npm start` in this repo did kinda render but the css was messed up. So I can see the content but it doesn't look great :) I presume that's not me. Let me know if I missed something.

Let me know if you have ideas to make it better and I'll hack on it when I have a moment (or feel free to push to this branch/PR, I made sure maintainers have edit rights).



-----
- [x] Forked the repo and created your branch from ~`master`~ `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

