### PR TITLE
add sandbox-startup reference

### DIFF
--- a/src/views/docs/en/reference/prefs.arc/sandbox-startup.md
+++ b/src/views/docs/en/reference/prefs.arc/sandbox-startup.md
@@ -1,0 +1,15 @@
+---
+title: '@sandbox-startup'
+description: Sandbox scripts
+---
+
+Hook up CLI commands into [`arc sandbox`](../cli/sandbox) startup. Helpful for repetitive tasks like seeding a database or starting up additional services for local development.
+
+### Example
+
+Execute arbitrary commands or scripts on [`arc sandbox`](../cli/sandbox) startup.
+
+```arc
+@sandbox-startup
+  node scripts/seed_db.js
+```

--- a/src/views/docs/en/reference/prefs.arc/sandbox.md
+++ b/src/views/docs/en/reference/prefs.arc/sandbox.md
@@ -3,9 +3,9 @@ title: '@sandbox'
 description: Sandbox environment variables
 ---
 
-> Architect preferences (`preferences.arc`, or `prefs.arc`) defines settings for local Architect workflows. This file is intended to be added to `.gitignore`.
+> Architect preferences (`preferences.arc`, or `prefs.arc`) defines settings for local Architect workflows.
 
-Define `arc sandbox` preferences.
+Define [`arc sandbox`](../cli/sandbox) preferences. If you are not using a [`.env` file](.env) then any environment variables set using the [`arc env` CLI](../cli/env) will be stored in the preferences file. In this scenario it is best _not_ to revision the preferences file in source control.
 
 ### `env` - Boolean
 
@@ -25,16 +25,4 @@ Advanced option that uses live AWS infrastructure where deployed, specifically: 
 ```arc
 @sandbox
 useAWS true
-```
-
-### `startup`
-
-Execute arbitrary commands or scripts on Sandbox startup.
-
-```arc
-@sandbox
-startup
-  echo 'Hi there!'
-  npm run test
-  node some/arbitrary/script.js
 ```

--- a/src/views/docs/table-of-contents.js
+++ b/src/views/docs/table-of-contents.js
@@ -80,7 +80,8 @@ let Reference = [ {
     '@create',
     '@env',
     '.env',
-    '@sandbox'
+    '@sandbox',
+    '@sandbox-startup'
   ]
 } ]
 


### PR DESCRIPTION
- move startup script info there.
- add to table of contents.
- clarify where env vars are stored on preferences.arc reference page, link to .env page.
- link up references to cli commands

