### PR TITLE
Added step 2 bullet for route53 & cloudfront

### DIFF
--- a/src/views/docs/en/guides/domains/route53-and-cloudfront.md
+++ b/src/views/docs/en/guides/domains/route53-and-cloudfront.md
@@ -31,6 +31,7 @@ Generate a CloudFront distribution with the certificate from step 1.
 - Set `Viewer Protocol Policy` to `Redirect HTTP to HTTPS`
 - Set `Allowed HTTP Methods` to `GET, HEAD, OPTIONS, PUT, POST, PATCH, DELETE`
 - Set `Compress Objects Automatically` to `Yes`
+- Enter the domain alias in `Alternate Domain Names` (which you will configure in step 3)
 - Set `SSL Certificate` to `Custom SSL Certificate` and select the cert from step 1
 - Click `Create Distribution`
 


### PR DESCRIPTION
AWS now requires aliases used to be entered in the "Alternate Domain Names" field (see https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-cloudfront-distribution.html)

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
