### PR TITLE
Update timeout.md

### DIFF
--- a/src/views/docs/en/reference/config.arc/timeout.md
+++ b/src/views/docs/en/reference/config.arc/timeout.md
@@ -5,10 +5,11 @@ description: Lambda function configuration
 
 Configure Lambda function `timeout` in seconds to a max of `900`. (`15` minutes.)
 
+The default timeout (if no value supplied) is `5`. (`5` seconds.)
+
 ## Example
 
 ```arc
 @aws
 timeout 30
 ```
-


### PR DESCRIPTION
Call out the default behaviour. Only concern is that I believe Architect leaves this value undefined when pushing to CloudFormation, so we're actually depending on whatever AWS' default is - but 5s is the default enforced by Sandbox, so feels reasonable to define here?
