### PR TITLE
Use @architect/asap in catchall for static playground proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@architect/architect": "^9.0.0",
+    "@architect/asap": "^4.0.0",
     "@architect/eslint-config": "^1.0.0",
     "@architect/functions": "^4.0.0",
     "@architect/inventory": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "slugify": "^1.6.0",
     "spellchecker-cli": "^4.8.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.3.0"
+    "tape": "^5.3.0",
+    "tiny-json-http": "^7.3.0"
   },
   "eslintConfig": {
     "extends": "@architect/eslint-config"

--- a/src/http/any-catchall/index.js
+++ b/src/http/any-catchall/index.js
@@ -1,14 +1,15 @@
 let { http } = require('@architect/functions')
+let asap = require('@architect/asap')
 
 // middleware to preserve old urls
 let redirect = require('./redirect')
 
 // middleware proxy s3 assets
-let asap = http.proxy({
+let static = asap({
   spa: false,
   alias: {
     '/playground': '/playground.html'
   }
 })
 
-exports.handler = http.async(redirect, asap)
+exports.handler = http.async(redirect, static)

--- a/src/http/get-docs-000lang-catchall/highlighter.js
+++ b/src/http/get-docs-000lang-catchall/highlighter.js
@@ -1,7 +1,7 @@
 module.exports = function (hljs, escapeHtml, str, lang) {
   if (lang && hljs.getLanguage(lang)) {
     try {
-      return `<pre class="hljs mb0 mb1-lg"><code>${hljs.highlight(lang, str, true).value}</code></pre>`
+      return `<pre class="hljs mb0 mb1-lg"><code>${hljs.highlight(str, { language: lang, ignoreIllegals: true }).value}</code></pre>`
     }
     catch (err) {
       console.error(err)

--- a/test/sandbox-http-test.js
+++ b/test/sandbox-http-test.js
@@ -1,0 +1,21 @@
+let test = require('tape')
+let tiny = require('tiny-json-http')
+let sandbox = require('@architect/sandbox')
+
+const host = 'http://localhost:3333'
+
+test('sandbox HTTP request', async t => {
+  t.plan(4)
+
+  await sandbox.start({ quiet: true })
+  t.ok(true, `sandbox started on ${host}`)
+
+  let quickstart = await tiny.get({ url: `${host}/docs/en/guides/get-started/quickstart` })
+  t.ok(quickstart.body, 'got quickstart document')
+
+  let playground = await tiny.get({ url: `${host}/playground` })
+  t.ok(playground.body, 'got static playground document')
+
+  await sandbox.end()
+  t.ok(true, 'sandbox ended')
+})


### PR DESCRIPTION
## Summary

Use `@arcitect/asap` in lieu of `@architect/functions http.proxy` for static playground proxy in catchall.  
This became an issue when [functions was updated to ^4.0.0](https://github.com/architect/arc.codes/commit/a3529a50785920dbf8c6241a828ba77fed097e99#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R41) from 3.4.12

Also add a quick Sandbox HTTP smoke test.

Bonus: update call to highlight.js#highlight method to avoid deprecation notices per [this issue](https://github.com/highlightjs/highlight.js/issues/2277)

---

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [ ] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
