### PR TITLE
Expand "Local development"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@architect/architect": "^9.0.0",
+    "@architect/asap": "^4.0.0",
     "@architect/eslint-config": "^1.0.0",
     "@architect/functions": "^4.0.0",
     "@architect/inventory": "^2.0.4",
@@ -53,7 +54,8 @@
     "slugify": "^1.6.0",
     "spellchecker-cli": "^4.8.0",
     "tap-spec": "^5.0.0",
-    "tape": "^5.3.0"
+    "tape": "^5.3.0",
+    "tiny-json-http": "^7.3.0"
   },
   "eslintConfig": {
     "extends": "@architect/eslint-config"

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "js-yaml": "^4.1.0",
     "markdown-it": "^12.1.0",
     "markdown-it-anchor": "^8.1.2",
+    "markdown-it-attrs": "^4.0.0",
     "markdown-it-front-matter": "^0.2.3",
     "slugify": "^1.6.0",
     "spellchecker-cli": "^4.8.0",

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -34,6 +34,10 @@ html {
   width: 2rem;
   height: 2rem;
 }
+a[target="_blank"]::after {
+  content: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAQElEQVR42qXKwQkAIAxDUUdxtO6/RBQkQZvSi8I/pL4BoGw/XPkh4XigPmsUgh0626AjRsgxHTkUThsG2T/sIlzdTsp52kSS1wAAAABJRU5ErkJggg==);
+  margin: 0 3px 0 5px;
+}
 .logo {
   width: 8rem;
 }

--- a/public/static.json
+++ b/public/static.json
@@ -5,7 +5,7 @@
   "playground.js": "playground-67bb53bc87.js",
   "components/arc-tab.js": "components/arc-tab-efbcb40f74.js",
   "components/arc-viewer.js": "components/arc-viewer-53669af1ac.js",
-  "css/index.css": "css/index-d0b9d5ab0b.css",
+  "css/index.css": "css/index-1c4efdce8d.css",
   "css/styles.css": "css/styles-75499ddd30.css",
   "css/syntax.css": "css/syntax-605168cf6d.css"
 }

--- a/src/http/any-catchall/index.js
+++ b/src/http/any-catchall/index.js
@@ -1,14 +1,15 @@
 let { http } = require('@architect/functions')
+let asap = require('@architect/asap')
 
 // middleware to preserve old urls
 let redirect = require('./redirect')
 
 // middleware proxy s3 assets
-let asap = http.proxy({
+let static = asap({
   spa: false,
   alias: {
     '/playground': '/playground.html'
   }
 })
 
-exports.handler = http.async(redirect, asap)
+exports.handler = http.async(redirect, static)

--- a/src/http/any-catchall/index.js
+++ b/src/http/any-catchall/index.js
@@ -5,11 +5,11 @@ let asap = require('@architect/asap')
 let redirect = require('./redirect')
 
 // middleware proxy s3 assets
-let static = asap({
+let staticProxy = asap({
   spa: false,
   alias: {
     '/playground': '/playground.html'
   }
 })
 
-exports.handler = http.async(redirect, static)
+exports.handler = http.async(redirect, staticProxy)

--- a/src/http/get-docs-000lang-catchall/highlighter.js
+++ b/src/http/get-docs-000lang-catchall/highlighter.js
@@ -1,7 +1,7 @@
 module.exports = function (hljs, escapeHtml, str, lang) {
   if (lang && hljs.getLanguage(lang)) {
     try {
-      return `<pre class="hljs mb0 mb1-lg"><code>${hljs.highlight(lang, str, true).value}</code></pre>`
+      return `<pre class="hljs mb0 mb1-lg"><code>${hljs.highlight(str, { language: lang, ignoreIllegals: true }).value}</code></pre>`
     }
     catch (err) {
       console.error(err)

--- a/src/http/get-docs-000lang-catchall/index.js
+++ b/src/http/get-docs-000lang-catchall/index.js
@@ -5,6 +5,7 @@ const fs = require('fs')
 const Markdown = require('markdown-it')
 const markdownClass = require('@toycode/markdown-it-class')
 const markdownAnchor = require('markdown-it-anchor')
+const markdownItAttrs = require('markdown-it-attrs')
 const frontmatterParser = require('markdown-it-front-matter')
 const classMapping = require('./markdown-class-mappings')
 const hljs = require('highlight.js')
@@ -81,6 +82,9 @@ exports.handler = async function http (req) {
     .use(markdownClass, classMapping)
     .use(markdownAnchor, {
       permalinkSymbol: ' '
+    })
+    .use(markdownItAttrs, {
+      allowedAttributes: []  // empty array = all attributes are allowed
     })
     .use(frontmatterParser, function (str) {
       frontmatter = yaml.load(str)

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -87,13 +87,13 @@ cd src/events/hit-counter
 npm install @architect/functions
 ```
 
-3. From the project root start up the sandbox if it is not already running:
+3. From the project root start up the [sandbox](../../reference/cli/sandbox) if it is not already running:
 
 ```console
 arc sandbox
 ```
 
-Architect will hydrate your [shared code](/docs/en/guides/developer-experience/sharing-code) and run the updated Architect project.
+[`arc sandbox`](../../reference/cli/sandbox) will automatically [hydrate - that is, install needed dependencies](../../reference/cli/hydrate) - for every function making up your Architect project.
 
 > 📖 Read more about [dependency management](/docs/en/guides/developer-experience/dependency-management).
 
@@ -103,4 +103,4 @@ With an Architect project running locally, there are several ways to work on you
 
 You can run a front-end application from the same Architect project to communicate with the back-end or use a client to interface with HTTP functions.
 
-Of course, the best way to catch bugs is by [testing your Architect project](/docs/en/guides/developer-experience/testing).
+Of course, the best way to catch bugs is by [testing your Architect project](testing).

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -8,7 +8,7 @@ Fast local development creates a tighter feedback loop, maximizing developer vel
 
 ## Running locally
 
-> 🏁 To set up Architect locally follow the [quickstart guide](/docs/en/guides/get-started/quickstart).
+> 🏁 To set up Architect locally follow the [quickstart guide](../../guides/get-started/quickstart).
 
 Preview a project running locally in a web browser by starting Architect's Sandbox:
 
@@ -17,19 +17,19 @@ cd myproject
 arc sandbox
 ```
 
->  [`arc sandbox`](/docs/en/reference/cli/sandbox) spins up a local web server with all the resources defined in manifest, emulating a suite of AWS features.
+>  [`arc sandbox`](../../reference/cli/sandbox) spins up a local web server with all the resources defined in manifest, emulating a suite of AWS features.
 
-Checkout [a complete example project for working locally](https://github.com/architect-examples/arc-example-working-locally).
+Check out [a complete example project for working locally](https://github.com/architect-examples/arc-example-working-locally){target=_blank}.
 
 ## Creating a new resource
 
-You can create a new resource (HTTP route, event, scheduled task, etc.) to an existing project by simply adding a line to the [Architect manifest file](/docs/en/guides/get-started/project-layout#manifest-file-format-overview). The following example will provision a new "hit counter" event.
+You can create a new resource (HTTP route, event, scheduled task, etc.) to an existing project by simply adding a line to the [Architect manifest file](../../guides/get-started/project-layout#manifest-file-format-overview). The following example will provision a new "hit counter" event.
 
-> 👉 Note: this example uses Node.js conventions but the process is similar for the [Ruby](/docs/en/reference/runtime/ruby) (bundler) and [Python](/docs/en/reference/runtime/python) (pip) runtimes.
+> 👉 Note: this example uses Node.js conventions but the process is similar for the [Ruby](../../reference/runtime/ruby) (bundler) and [Python](../../reference/runtime/python) (pip) runtimes.
 
 ### Update Architect's configuration
 
-To create a new event, add an entry to your manifest's [`@events` pragma](/docs/en/reference/app.arc/events).
+To create a new event, add an entry to your manifest's [`@events` pragma](../../reference/app.arc/events).
 
 Sample `app.arc` file with a new `hit-counter` event:
 
@@ -46,7 +46,7 @@ hit-counter
 
 ### Scaffold the new resource with `arc init`
 
-The Architect CLI [`init` command](/docs/en/reference/cli/init) can be used to create scaffolding for the new event. From the project root:
+The Architect CLI [`init` command](../../reference/cli/init) can be used to create scaffolding for the new event. From the project root:
 
 ```console
 arc init
@@ -54,7 +54,7 @@ arc init
 
 > 👀 Notice that `arc` finds your updated Architect manifest and creates new project files for the hit-counter event. `arc init` can be run as needed while developing your application.
 
-The following structure was added your project:
+The following structure was added to your project:
 <!-- unsure if this diagram is necessary -->
 ```
 .
@@ -69,33 +69,23 @@ The following structure was added your project:
 
 ### Add dependencies (optional)
 
-Your new event may require some dependencies. For this example, [@architect/functions](https://github.com/architect/functions) will be helpful to handle the event subscription. Dependencies can be installed directly to the `hit-counter` directory:
+Your new event may require some dependencies. For this example, [the @architect/functions runtime helper library](../../reference/runtime/node.js) will be helpful to handle the event subscription. [Dependencies in Node.js can be managed](dependency-management) either globally from the root `package.json`, or managed via separate `package.json` files in each function's directory. This example will use the project's main `package.json` to take advantage of Architect's tree-shaking:
 
-1. Inside `./src/events/hit-counter` create a `package.json` file with an empty `dependencies` entry:
-
-```json
-// package.json
-{
-  "dependencies": {}
-}
-```
-
-2. Install dependencies with `npm`:
+From the root, install dependencies with `npm`:
 
 ```console
-cd src/events/hit-counter
 npm install @architect/functions
 ```
 
-3. From the project root start up the [sandbox](../../reference/cli/sandbox) if it is not already running:
+Start up the [sandbox](../../reference/cli/sandbox):
 
 ```console
 arc sandbox
 ```
 
-[`arc sandbox`](../../reference/cli/sandbox) will automatically [hydrate - that is, install needed dependencies](../../reference/cli/hydrate) - for every function making up your Architect project.
+[`arc sandbox`](../../reference/cli/sandbox) will automatically [hydrate](../../reference/cli/hydrate) (install dependencies) and determine an optimal `node_modules` for each function in your Architect project.
 
-> 📖 Read more about [dependency management](/docs/en/guides/developer-experience/dependency-management).
+> 📖 Read more about [dependency management](../../guides/developer-experience/dependency-management).
 
 ## Debugging
 

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -8,7 +8,7 @@ Fast local development creates a tighter feedback loop maximizing developer velo
 
 ## Running locally
 
-> To set up Architect locally follow the [quickstart guide](/docs/en/guides/get-started/quickstart).
+> ℹ️ To set up Architect locally follow the [quickstart guide](/docs/en/guides/get-started/quickstart).
 
 Preview a project running locally in a web browser:
 
@@ -23,13 +23,13 @@ Checkout [a complete example project for working locally](https://github.com/arc
 
 ## Creating a new resource
 
-Adding a new resource ([@http](/docs/en/reference/app.arc/http) endpoint, [@events](/docs/en/reference/app.arc/events), [@scheduled](/docs/en/reference/app.arc/scheduled), etc.) to an existing project is as simple as adding an entry to the [Architect manifest](/docs/en/guides/get-started/project-layout#manifest-file-format-overview).
+Adding a new resource (HTTP route, event, scheduled task, etc.) to an existing project is as simple as adding an entry to the [Architect manifest](/docs/en/guides/get-started/project-layout#manifest-file-format-overview).
 
-> 👉 Note: this example will use Node.js conventions but the process is similar for the [Ruby](/docs/en/reference/runtime/ruby) (bundler) and [Python](/docs/en/reference/runtime/python) (pip) runtimes.
+> 👉 Note: this example uses Node.js conventions but the process is similar for the [Ruby](/docs/en/reference/runtime/ruby) (bundler) and [Python](/docs/en/reference/runtime/python) (pip) runtimes.
 
 ### Update Architect's configuration
 
-Add an entry under the `@events` pragma (if it doesn't exist, add it on a new line) for a new "hit counter" event:
+Add an entry for a new "hit counter" event under the [`@events` pragma](/docs/en/reference/app.arc/events) (if it doesn't exist, go ahead and add it):
 
 ```arc
 # app.arc
@@ -48,7 +48,18 @@ Architect's CLI [`init` command](/docs/en/reference/cli/init) can be used to cre
 arc init
 ```
 
-> 👀 Notice the CLI found an existing Architect manifest and new project files were created in `./src/events/hit-counter/` for the added event.
+> 👀 Notice the CLI found an existing Architect manifest and new project files were created for the added event.
+
+The following structure was added:
+
+```
+.
+├── src
+│   └── events
+│       └── hit-counter/index.js
+│
+└── app.arc
+```
 
 ### Add dependencies
 

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -4,7 +4,7 @@ category: Developer experience
 description: How to develop locally with Architect sandbox
 ---
 
-Fast local development creates a tighter feedback loop maximizing developer velocity. Architect provides utilities to provision resources, run locally, and debug applications.
+Fast local development creates a tighter feedback loop maximizing developer velocity. Architect provides utilities to run applications locally, provision new resources, and debug.
 
 ## Running locally
 
@@ -17,7 +17,7 @@ cd myproject
 arc sandbox
 ```
 
->  [`arc sandbox`](/docs/en/reference/cli/sandbox) spins up a local web server with all the resources defined in your `app.arc` file, emulating a suite of AWS features.
+>  [`arc sandbox`](/docs/en/reference/cli/sandbox) spins up a local web server with all the resources defined in manifest, emulating a suite of AWS features.
 
 Checkout [a complete example project for working locally](https://github.com/architect-examples/arc-example-working-locally).
 
@@ -29,7 +29,7 @@ Adding a new resource (HTTP route, event, scheduled task, etc.) to an existing p
 
 ### Update Architect's configuration
 
-Add an entry for a new "hit counter" event under the [`@events` pragma](/docs/en/reference/app.arc/events) (if it doesn't exist, go ahead and add it):
+Add an entry for a new "hit counter" event under the [`@events` pragma](/docs/en/reference/app.arc/events) (if "@events" configuration doesn't exist, go ahead and add it):
 
 ```arc
 # app.arc
@@ -63,7 +63,7 @@ The following structure was added:
 
 ### Add dependencies
 
-The new event may require some dependencies. For this Node.js example @architect/functions {LINK} will be helpful to handle the event subscription. Ensure this requirement is met:
+The new event may require some dependencies. For this Node.js example, [@architect/functions](https://github.com/architect/functions) will be helpful to handle the event subscription. Ensure this requirement is met:
 
 1. In the generated `./src/events/hit-counter` directory create a `package.json` file with an empty `dependencies` entry:
 
@@ -95,4 +95,4 @@ With an Architect project running locally, there are several ways to develop and
 
 Developers can run a front-end application from the same Architect project to communicate with the back-end or use a client to interface with HTTP functions.
 
-Of course, the best way to catch bugs is by [testing your Architect project](/docs/en/guides/developer-experience/testing).
+Of course, the best way to catch bugs is by [testing an Architect project](/docs/en/guides/developer-experience/testing).

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -4,13 +4,13 @@ category: Developer experience
 description: How to develop locally with Architect sandbox
 ---
 
-Fast local development creates a tighter feedback loop maximizing developer velocity. Architect provides utilities to run applications locally, provision new resources, and debug.
+Fast local development creates a tighter feedback loop, maximizing developer velocity. Architect provides utilities to run projects locally, provision new resources, and debug your application.
 
 ## Running locally
 
-> ℹ️ To set up Architect locally follow the [quickstart guide](/docs/en/guides/get-started/quickstart).
+> 🏁 To set up Architect locally follow the [quickstart guide](/docs/en/guides/get-started/quickstart).
 
-Preview a project running locally in a web browser:
+Preview a project running locally in a web browser by starting Architect's Sandbox:
 
 ```console
 cd myproject
@@ -23,13 +23,15 @@ Checkout [a complete example project for working locally](https://github.com/arc
 
 ## Creating a new resource
 
-Adding a new resource (HTTP route, event, scheduled task, etc.) to an existing project is as simple as adding an entry to the [Architect manifest](/docs/en/guides/get-started/project-layout#manifest-file-format-overview).
+You can create a new resource (HTTP route, event, scheduled task, etc.) to an existing project by simply adding a line to the [Architect manifest file](/docs/en/guides/get-started/project-layout#manifest-file-format-overview). The following example will provision a new "hit counter" event.
 
 > 👉 Note: this example uses Node.js conventions but the process is similar for the [Ruby](/docs/en/reference/runtime/ruby) (bundler) and [Python](/docs/en/reference/runtime/python) (pip) runtimes.
 
 ### Update Architect's configuration
 
-Add an entry for a new "hit counter" event under the [`@events` pragma](/docs/en/reference/app.arc/events) (if "@events" configuration doesn't exist, go ahead and add it):
+To create a new event, add an entry to your manifest's [`@events` pragma](/docs/en/reference/app.arc/events).
+
+Sample `app.arc` file with a new `hit-counter` event:
 
 ```arc
 # app.arc
@@ -40,32 +42,36 @@ my-app
 hit-counter
 ```
 
-### Scaffold with `arc init`
+> 💡 If the pragma does not already exist, add "@events" on a new line.
 
-Architect's CLI [`init` command](/docs/en/reference/cli/init) can be used to create some scaffolding for the new event. From the project root:
+### Scaffold the new resource with `arc init`
+
+The Architect CLI [`init` command](/docs/en/reference/cli/init) can be used to create scaffolding for the new event. From the project root:
 
 ```console
 arc init
 ```
 
-> 👀 Notice the CLI found an existing Architect manifest and new project files were created for the added event.
+> 👀 Notice that `arc` finds your updated Architect manifest and creates new project files for the hit-counter event. `arc init` can be run as needed while developing your application.
 
-The following structure was added:
-
+The following structure was added your project:
+<!-- unsure if this diagram is necessary -->
 ```
 .
 ├── src
 │   └── events
-│       └── hit-counter/index.js
+│       └── hit-counter
+│           ├── index.js
+│           └── config.arc
 │
 └── app.arc
 ```
 
-### Add dependencies
+### Add dependencies (optional)
 
-The new event may require some dependencies. For this Node.js example, [@architect/functions](https://github.com/architect/functions) will be helpful to handle the event subscription. Ensure this requirement is met:
+Your new event may require some dependencies. For this example, [@architect/functions](https://github.com/architect/functions) will be helpful to handle the event subscription. Dependencies can be installed directly to the `hit-counter` directory:
 
-1. In the generated `./src/events/hit-counter` directory create a `package.json` file with an empty `dependencies` entry:
+1. Inside `./src/events/hit-counter` create a `package.json` file with an empty `dependencies` entry:
 
 ```json
 // package.json
@@ -74,25 +80,27 @@ The new event may require some dependencies. For this Node.js example, [@archite
 }
 ```
 
-2. Install dependencies
+2. Install dependencies with `npm`:
 
 ```console
 cd src/events/hit-counter
-npm i @architect/functions
+npm install @architect/functions
 ```
 
-3. From the project root start the sandbox
+3. From the project root start up the sandbox if it is not already running:
 
 ```console
 arc sandbox
 ```
 
-Architect will hydrate [shared code](/docs/en/guides/developer-experience/sharing-code) and run the updated Architect project.
+Architect will hydrate your [shared code](/docs/en/guides/developer-experience/sharing-code) and run the updated Architect project.
+
+> 📖 Read more about [dependency management](/docs/en/guides/developer-experience/dependency-management).
 
 ## Debugging
 
-With an Architect project running locally, there are several ways to develop and debug an application.
+With an Architect project running locally, there are several ways to work on your application.
 
-Developers can run a front-end application from the same Architect project to communicate with the back-end or use a client to interface with HTTP functions.
+You can run a front-end application from the same Architect project to communicate with the back-end or use a client to interface with HTTP functions.
 
-Of course, the best way to catch bugs is by [testing an Architect project](/docs/en/guides/developer-experience/testing).
+Of course, the best way to catch bugs is by [testing your Architect project](/docs/en/guides/developer-experience/testing).

--- a/src/views/docs/en/guides/developer-experience/testing.md
+++ b/src/views/docs/en/guides/developer-experience/testing.md
@@ -1,0 +1,102 @@
+---
+title: Testing
+category: Developer experience
+description: How to test with Architect
+---
+
+## Testing
+
+### Testing `@http` functions
+
+Use `@architect/sandbox` as a module to test `@http` functions with Node:
+
+```javascript
+const test = require('tape')
+const tiny = require('tiny-json-http')
+const sandbox = require('@architect/sandbox')
+
+test('setup', async t=> {
+  t.plan(1)
+  await sandbox.start()
+  t.ok(true, 'sandbox started on http://localhost:3333')
+})
+
+test('get /', async t=> {
+  t.plan(1)
+  let result = await tiny.get({ url: 'http://localhost:3333' })
+  t.ok(result, 'got 200 response')
+})
+
+test('teardown', async t=> {
+  t.plan(1)
+  await sandbox.end()
+  t.ok(true, 'sandbox ended')
+})
+```
+
+### Testing `@events` and `@queues`
+
+Use `@architect/functions` to publish locally to `@events` or `@queues` for testing.
+
+```javascript
+const test = require('tape')
+const arc = require('@architect/functions')
+const sandbox = require('@architect/sandbox')
+
+test('setup', async t=>{
+  t.plan(1)
+  await sandbox.start()
+  t.ok(true, 'started')
+})
+
+test('@events', async t=> {
+  t.plan(1)
+  // mock pingID
+  let pingID = 'testing-ping'
+  // send a ping event
+  await arc.events.publish({
+    name: 'ping',
+    payload: { pingID }
+  })
+  // see if testing-ping is in the db
+  let data = await arc.tables()
+  let { hits } = await data.pings.get({ pingID })
+  t.ok(hits, 'pong!')
+})
+
+test('teardown', async t=>{
+  t.plan(1)
+  await sandbox.end()
+  t.ok(true, 'closed')
+})
+
+```
+
+### Testing `@tables`
+
+Using `@architect/functions` to interact with DynamoDB `@tables` defined locally.
+
+```javascript
+const test = require('tape')
+const arc = require('@architect/functions')
+const sandbox = require('@architect/sandbox')
+
+test('setup', async t=>{
+  t.plan(1)
+  await sandbox.start()
+  t.ok(true, 'started')
+})
+
+test('db', t=> {
+  t.plan(1)
+  let data = await arc.tables()
+  let cats = await data.cats.scan({})
+  t.ok(Array.isArray(cats.Items), 'bag o cats')
+})
+
+test('teardown', async t=>{
+  t.plan(1)
+  await sandbox.end()
+  t.ok(true, 'closed')
+})
+```

--- a/src/views/docs/en/guides/developer-experience/testing.md
+++ b/src/views/docs/en/guides/developer-experience/testing.md
@@ -1,12 +1,12 @@
 ---
 title: Testing
 category: Developer experience
-description: How to test with Architect
+description: How to test your Architect project
 ---
 
 ### `@http` functions
 
-Use `@architect/sandbox` as a module to test `@http` functions with Node:
+Use `@architect/sandbox` as a module to test [`@http`](../../reference/app.arc/http) functions with Node:
 
 ```javascript
 const test = require('tape')
@@ -34,7 +34,7 @@ test('teardown', async t=> {
 
 ### `@events` and `@queues`
 
-Use `@architect/functions` to publish locally to `@events` or `@queues` for testing.
+Use [`@architect/functions`](../../reference/runtime/node.js) to publish locally to [`@events`](../../reference/app.arc/events) or [`@queues`](../../reference/app.arc/queues) for testing.
 
 ```javascript
 const test = require('tape')
@@ -72,7 +72,7 @@ test('teardown', async t=>{
 
 ### `@tables`
 
-Using `@architect/functions` to interact with DynamoDB `@tables` defined locally.
+Using `@architect/functions` to interact with DynamoDB [`@tables`](../../reference/app.arc/tables) defined locally.
 
 ```javascript
 const test = require('tape')

--- a/src/views/docs/en/guides/developer-experience/testing.md
+++ b/src/views/docs/en/guides/developer-experience/testing.md
@@ -16,7 +16,7 @@ const sandbox = require('@architect/sandbox')
 test('setup', async t=> {
   t.plan(1)
   await sandbox.start()
-  t.ok(true, 'sandbox started on http://localhost:3333')
+  t.pass('sandbox started on http://localhost:3333')
 })
 
 test('get /', async t=> {
@@ -28,7 +28,7 @@ test('get /', async t=> {
 test('teardown', async t=> {
   t.plan(1)
   await sandbox.end()
-  t.ok(true, 'sandbox ended')
+  t.pass('sandbox ended')
 })
 ```
 
@@ -44,7 +44,7 @@ const sandbox = require('@architect/sandbox')
 test('setup', async t=>{
   t.plan(1)
   await sandbox.start()
-  t.ok(true, 'started')
+  t.pass('started')
 })
 
 test('@events', async t=> {
@@ -65,7 +65,7 @@ test('@events', async t=> {
 test('teardown', async t=>{
   t.plan(1)
   await sandbox.end()
-  t.ok(true, 'closed')
+  t.pass('closed')
 })
 
 ```
@@ -82,7 +82,7 @@ const sandbox = require('@architect/sandbox')
 test('setup', async t=>{
   t.plan(1)
   await sandbox.start()
-  t.ok(true, 'started')
+  t.pass('started')
 })
 
 test('db', t=> {
@@ -95,6 +95,6 @@ test('db', t=> {
 test('teardown', async t=>{
   t.plan(1)
   await sandbox.end()
-  t.ok(true, 'closed')
+  t.pass('closed')
 })
 ```

--- a/src/views/docs/en/guides/developer-experience/testing.md
+++ b/src/views/docs/en/guides/developer-experience/testing.md
@@ -4,9 +4,7 @@ category: Developer experience
 description: How to test with Architect
 ---
 
-## Testing
-
-### Testing `@http` functions
+### `@http` functions
 
 Use `@architect/sandbox` as a module to test `@http` functions with Node:
 
@@ -34,7 +32,7 @@ test('teardown', async t=> {
 })
 ```
 
-### Testing `@events` and `@queues`
+### `@events` and `@queues`
 
 Use `@architect/functions` to publish locally to `@events` or `@queues` for testing.
 
@@ -72,7 +70,7 @@ test('teardown', async t=>{
 
 ```
 
-### Testing `@tables`
+### `@tables`
 
 Using `@architect/functions` to interact with DynamoDB `@tables` defined locally.
 

--- a/src/views/docs/table-of-contents.js
+++ b/src/views/docs/table-of-contents.js
@@ -6,7 +6,8 @@ let Guides = [ {
     'Detailed AWS setup',
   ],
   'Developer experience': [
-    'Local development', // preview, debug and test
+    'Local development', // preview, create resource, and debug
+    'Testing',
     'Dependency management',
     'Sharing code', // src/shared and src/views
     'Custom source paths',

--- a/test/sandbox-http-test.js
+++ b/test/sandbox-http-test.js
@@ -1,0 +1,21 @@
+let test = require('tape')
+let tiny = require('tiny-json-http')
+let sandbox = require('@architect/sandbox')
+
+const host = 'http://localhost:3333'
+
+test('sandbox HTTP request', async t => {
+  t.plan(4)
+
+  await sandbox.start({ quiet: true })
+  t.ok(true, `sandbox started on ${host}`)
+
+  let quickstart = await tiny.get({ url: `${host}/docs/en/guides/get-started/quickstart` })
+  t.ok(quickstart.body, 'got quickstart document')
+
+  let playground = await tiny.get({ url: `${host}/playground` })
+  t.ok(playground.body, 'got static playground document')
+
+  await sandbox.end()
+  t.ok(true, 'sandbox ended')
+})

--- a/test/sandbox-http-test.js
+++ b/test/sandbox-http-test.js
@@ -8,7 +8,7 @@ test('sandbox HTTP request', async t => {
   t.plan(4)
 
   await sandbox.start({ quiet: true })
-  t.ok(true, `sandbox started on ${host}`)
+  t.pass(`sandbox started on ${host}`)
 
   let quickstart = await tiny.get({ url: `${host}/docs/en/guides/get-started/quickstart` })
   t.ok(quickstart.body, 'got quickstart document')
@@ -17,5 +17,5 @@ test('sandbox HTTP request', async t => {
   t.ok(playground.body, 'got static playground document')
 
   await sandbox.end()
-  t.ok(true, 'sandbox ended')
+  t.pass('sandbox ended')
 })


### PR DESCRIPTION
> 🚧   **WIP**: creating draft PR to coordinate with Ryan, but all feedback welcome :)

## Changes

### Expand "_Local development_"

I added an example for "_Creating a new resource_". I used a hypothetical "hit counter" example. `arc init` is used for scaffolding (mentioned in [this issue](https://github.com/architect/arc.codes/issues/312))
This type of workflow was a point of interest as I was building my first app.

Stub out "_Debugging_" section that may or may not be necessary. Leads into testing.

### Move "_Testing_" to its own document

Testing is definitely a part of "local dev" but probably warrants its own doc.

## More ideas for "Local development"

* provide a short implementation of the "hit counter" event feature, just to tie it all together
* use inline tabs to demonstrate Ruby and Python alongside the Node example
* elaborate on what Architect Sandbox emulates locally (and how?)
  * ie. queues, events, dynalite
  * this is covered in `reference/cli/sandbox`, but there might be an opportunity to tout some of the capabilities without requiring the reader to dig too far.

~I avoided second person, but after [research](https://docs.microsoft.com/en-us/style-guide/grammar/person) on [style guides](https://developers.google.com/style/person) by [large orgs](https://developer.salesforce.com/docs/atlas.en-us.salesforce_pubs_style_guide.meta/salesforce_pubs_style_guide/style_second_person.htm), I'll change it.~

---

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes
