### PR TITLE
Add arc-plugin-esbuild to the list of plugins

### DIFF
--- a/scripts/dictionary.js
+++ b/scripts/dictionary.js
@@ -116,6 +116,7 @@ let dictionary = [
   'envs',
   'EOL',
   'errback',
+  'esbuild',
   'eslint',
   'esmodules',
   'EventBridge',

--- a/src/views/docs/en/guides/extend/plugins.md
+++ b/src/views/docs/en/guides/extend/plugins.md
@@ -427,6 +427,7 @@ module.exports = {
 
 - [plugin-iot-rules](https://www.npmjs.com/package/@copper/plugin-iot-rules): adds AWS IoT Topic event Lambdas
 - [plugin-parcel](https://www.npmjs.com/package/@copper/plugin-parcel): compiles project Lambda code with the Parcel bundler both during local development via [`sandbox`][sandbox] and before [`deploy`s][deploy]
+- [arc-plugin-esbuild](https://www.npmjs.com/package/arc-plugin-esbuild): compiles project Lambda code with the esbuild bundler watching during local development via [`sandbox`][sandbox] and before [`deploy`s][deploy]
 - [arc-plugin-s3-image-bucket](https://www.npmjs.com/package/arc-plugin-s3-image-bucket): manages an S3 bucket purpose-built for allowing direct-from-user image uploads, includes support for customizable Lambda triggers based on bucket events
 
 [inv]: https://github.com/architect/inventory


### PR DESCRIPTION
Confirmed it's `esbuild` and not any other capitalization

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
