### PR TITLE
fix: pull request template references master

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:
 
-- [ ] Forked the repo and created your branch from `master`
+- [ ] Forked the repo and created your branch from `main`
 - [ ] Made sure tests pass (run `npm it` from the repo root)
 - [ ] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
 - [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes


### PR DESCRIPTION
It is now `main`

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `master`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
