### PR TITLE
Docs group landing view

### DIFF
--- a/src/http/get-docs-000lang-catchall/group-index.js
+++ b/src/http/get-docs-000lang-catchall/group-index.js
@@ -1,0 +1,38 @@
+const slugify = require('@architect/views/modules/helpers/slugify').default
+
+module.exports = function createGroupIndex (pathParts, toc) {
+  const mainSlug = pathParts.shift()
+  const tocSlugsMap = Object.fromEntries(Object.keys(toc).map(t => [ slugify(t), t ]))
+  const mainTitle = tocSlugsMap[mainSlug]
+  const mainGroup = toc[mainTitle]
+  let groupTitle
+  let groupPages
+
+  if (mainGroup) {
+    pathParts.forEach((slug) => {
+      let groupSlugs = {} // maintain slug lookup
+      // ! this smells:
+      const subGroup = (groupPages ? groupPages : mainGroup).find((group) => {
+        groupSlugs = {} // reset lookup
+        Object.keys(group).forEach(g => groupSlugs[slugify(g)] = g)
+        return group[groupSlugs[slug]]
+      })
+
+      groupTitle = groupSlugs[slug]
+      groupPages = subGroup[groupTitle]
+    })
+  }
+
+  // ? TODO: create `children` from category "index.md" content if it exists
+
+  if (groupPages) {
+    return {
+      title: groupTitle,
+      category: mainTitle,
+      groupPages
+    }
+  }
+  else {
+    return null
+  }
+}

--- a/src/http/get-docs-000lang-catchall/index.js
+++ b/src/http/get-docs-000lang-catchall/index.js
@@ -11,6 +11,7 @@ const highlighter = require('./highlighter')
 const readFile = util.promisify(fs.readFile)
 const Html = require('@architect/views/modules/document/html.js').default
 const toc = require('@architect/views/docs/table-of-contents')
+const slugify = require('@architect/views/modules/helpers/slugify').default
 const yaml = require('js-yaml')
 const EDIT_DOCS = `edit/main/src/views/docs/`
 const cache = {} // cheap warm cache
@@ -18,7 +19,7 @@ const cache = {} // cheap warm cache
 exports.handler = async function http (req) {
   let { pathParameters } = req
   let { lang, proxy } = pathParameters
-  let parts = proxy.split('/')
+  let parts = proxy.replace(/\/$/, '').split('/')
   let docName = parts.pop()
 
   if (docName === 'playground')
@@ -58,12 +59,61 @@ exports.handler = async function http (req) {
     file = cache[filePath]
   }
   catch (err) {
-    // TODO: Load category "index" landing or load next in section
-    console.error(err)
-    return {
-      statusCode: 404,
-      // TODO: send a friendly error page with message
-      body: err.message
+    // TODO: pass this to a (tested) util with `pathParameters` object
+    const slugs = [...parts, docName]
+    const mainSlug = slugs.shift()
+    const tocSlugsMap = Object.fromEntries(Object.keys(toc).map(t => [slugify(t), t]))
+    const mainTitle = tocSlugsMap[mainSlug]
+    const mainGroup = toc[mainTitle]
+    let groupTitle
+    let groupPages
+
+    if (mainGroup) {
+      slugs.forEach((slug) => {
+        let groupSlugs = {} // maintain slug lookup
+        // ! this smells:
+        const subGroup = (groupPages ? groupPages : mainGroup).find((group) => {
+          groupSlugs = {} // reset lookup
+          Object.keys(group).forEach(g => groupSlugs[slugify(g)] = g)
+          return group[groupSlugs[slug]]
+        })
+
+        groupTitle = groupSlugs[slug]
+        groupPages = subGroup[groupTitle]
+      })
+    }
+
+    // ? TODO: create `children` from category "index.md" content if it exists
+
+    if (groupPages) {
+      return {
+        statusCode: 200,
+        headers: {
+          'cache-control': 'no-cache, no-store, must-revalidate, max-age=0, s-maxage=0',
+          'content-type': 'text/html; charset=utf8'
+        },
+        body: Html({
+          title: groupTitle,
+          category: mainTitle,
+          groupPages,
+          active,
+          lang,
+          scripts: [
+            '/index.js',
+            '/components/arc-viewer.js',
+            '/components/arc-tab.js'
+          ],
+          toc
+        })
+      }
+    } else {
+      console.error(err)
+
+      return {
+        statusCode: 404,
+        // TODO: send a friendly error page with message
+        body: err.message
+      }
     }
   }
 

--- a/src/views/modules/components/anchor.js
+++ b/src/views/modules/components/anchor.js
@@ -1,6 +1,6 @@
 export default function Anchor (props = {}) {
-  let { children, href = '#' } = props
+  let { children, classes = '', href = '#' } = props
   return `
-<a href=${href}>${children}</a>
+<a href="${href}" class="${classes}">${children}</a>
   `
 }

--- a/src/views/modules/components/group-index.js
+++ b/src/views/modules/components/group-index.js
@@ -13,11 +13,12 @@ export default function GroupIndex (props = {}) {
       const anchor = Anchor({
         children: page,
         classes: 'font-medium text-p1 text-h1',
-        href: [active, slugify(page)].join('/')
+        href: [ active, slugify(page) ].join('/')
       })
       const item = Item({ children: anchor })
       return item
-    } else {
+    }
+    else {
       // ? TODO: handle nested groups
     }
   }).join('')

--- a/src/views/modules/components/group-index.js
+++ b/src/views/modules/components/group-index.js
@@ -1,0 +1,26 @@
+import slugify from '../helpers/slugify.js'
+import List from './list.js'
+import Item from './item.js'
+import Anchor from './anchor.js'
+
+export default function GroupIndex (props = {}) {
+  let { groupPages, active } = props
+
+  if (!groupPages) return ''
+
+  const children = groupPages.map((page) => {
+    if (typeof page === 'string') {
+      const anchor = Anchor({
+        children: page,
+        classes: 'font-medium text-p1 text-h1',
+        href: [active, slugify(page)].join('/')
+      })
+      const item = Item({ children: anchor })
+      return item
+    } else {
+      // ? TODO: handle nested groups
+    }
+  }).join('')
+
+  return List({ children, classes: 'list-none ml-1 mb-1' })
+}

--- a/src/views/modules/components/item.js
+++ b/src/views/modules/components/item.js
@@ -1,7 +1,7 @@
 export default function Item (state = {}) {
-  let { children, classes } = state
+  let { children, classes = '' } = state
   return `
-<li class=${classes}>
+<li class="${classes}">
   ${children}
 </li>
   `

--- a/src/views/modules/components/list.js
+++ b/src/views/modules/components/list.js
@@ -1,7 +1,7 @@
 export default function List (props = {}) {
-  let { children, classes } = props
+  let { children, classes = '' } = props
   return `
-<ul class=${classes}>
+<ul class="${classes}">
   ${children}
 </ul>
   `

--- a/src/views/modules/document/html.js
+++ b/src/views/modules/document/html.js
@@ -5,6 +5,7 @@ import State from './state.js'
 import Logo from '../components/logo.js'
 import Icon from '../components/icon.js'
 import Sidebar from '../components/sidebar.js'
+import GroupIndex from '../components/group-index'
 import GithubLink from '../components/github-link.js'
 import SlackLink from '../components/slack-link.js'
 
@@ -127,10 +128,13 @@ ${Symbols}
           ${title}
         </h1>
         <div class="pb4 docs">
+          ${GroupIndex(props)}
           ${children}
-          <div class="flex justify-end mt4">
-            <a href="${editURL}" target="_blank" rel="noreferrer" class="text1 text-p1 text-h1 text-a2 no-underline font-semibold">Edit this doc on Github →</a>
-          </div>
+          ${editURL && `
+            <div class="flex justify-end mt4">
+              <a href="${editURL}" target="_blank" rel="noreferrer" class="text1 text-p1 text-h1 text-a2 no-underline font-semibold">Edit this doc on Github →</a>
+            </div>
+          `}
         </div>
       </div>
     </main>

--- a/test/group-index-test.js
+++ b/test/group-index-test.js
@@ -1,0 +1,106 @@
+const test = require('tape')
+const createGroupIndex = require('../src/http/get-docs-000lang-catchall/group-index')
+
+const fakeToc = {
+  Foo: [
+    {
+      'Arcu': 'nunc id cursus'.split(' '),
+      'Dictum': 'ullamcorper velit sed'.split(' '),
+      'Varius': [
+        'iaculis',
+        {
+          LOREM: [
+            'ipsum',
+            'dolor',
+            'sit'
+          ]
+        }
+      ]
+    }
+  ],
+  Bar: [ {
+    'pharetra': 'convallis posuere morbi leo'.split(' '),
+    'convallis': 'posuere morbi leo'.split(' '),
+    'posuere': 'morbi leo'.split(' '),
+    'morbi': [ 'leo' ]
+  } ],
+  Baz: 'fusce ut placerat orci nulla'.split(' ')
+}
+
+test('createGroupIndex: validate', t => {
+  t.equal(typeof createGroupIndex, 'function', 'it is a function')
+  t.end()
+})
+
+test.skip('createGroupIndex: top level group', t => {
+  t.deepEqual(
+    createGroupIndex([ 'baz' ], fakeToc),
+    {
+      title: 'Baz',
+      groupPages: [ 'fusce', 'ut', 'placerat', 'orci', 'nulla' ]
+    },
+    'extracts top level group'
+  )
+  t.end()
+})
+
+test('createGroupIndex: simple group from shallow path', t => {
+  t.deepEqual(
+    createGroupIndex([ 'bar', 'posuere' ], fakeToc),
+    {
+      title: 'posuere',
+      category: 'Bar',
+      groupPages: [ 'morbi', 'leo' ]
+    },
+    'extracts a shallow list'
+  )
+
+  t.deepEqual(
+    createGroupIndex([ 'foo', 'dictum' ], fakeToc),
+    {
+      title: 'Dictum',
+      category: 'Foo',
+      groupPages: [ 'ullamcorper', 'velit', 'sed' ]
+    },
+    'extracts an uppercase shallow list'
+  )
+
+  t.end()
+})
+
+test('createGroupIndex: nested list from path', t => {
+  t.deepEqual(
+    createGroupIndex([ 'foo', 'varius' ], fakeToc),
+    {
+      title: 'Varius',
+      category: 'Foo',
+      groupPages: [ 'iaculis', { LOREM: [ 'ipsum', 'dolor', 'sit' ] } ]
+    },
+    'extracts nested list'
+  )
+
+  t.end()
+})
+
+test('createGroupIndex: nested group from path', t => {
+  t.deepEqual(
+    createGroupIndex([ 'foo', 'varius', 'lorem' ], fakeToc),
+    {
+      title: 'LOREM',
+      category: 'Foo',
+      groupPages: [ 'ipsum', 'dolor', 'sit' ]
+    },
+    'extracts nested group from list'
+  )
+
+  t.end()
+})
+
+test.skip('createGroupIndex: path without children', t => {
+  t.notOk(
+    createGroupIndex([ 'foo', 'varius', 'iaculis' ], fakeToc),
+    'returns falsy for dead end'
+  )
+
+  t.end()
+})


### PR DESCRIPTION
## 🚧 WIP: A rough cut for how a doc group landing page index thing could work

<img width="910" alt="image" src="https://user-images.githubusercontent.com/15697/132635934-a2291dce-95f1-4d6c-8f70-b3abbfb860e9.png">

initial goal was to not modify table-of-contents

* need to break out group logic into util
* gotta test it -- there's some edge cases
  * doesn't work at top level like /guides
* added some comments re: TODO, questions, and a code smell
* sidebar doesn't actually link to these group indexes yet
* `GroupIndex()` can probably make use of the `listFromObject()` util to handle recursion

---

- [X] Forked the repo and created your branch from `main`
- [X] Made sure tests pass (run `npm it` from the repo root)
- [ ] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [-] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes
