### PR TITLE
Issue #381: Scrollable Code Blocks are not keyboard accessible

### DIFF
--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -21,6 +21,8 @@
 .docs pre.shiki {
   /* https://github.com/shikijs/shiki/issues/214 */
   background-color: var(--shiki-color-background) !important;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 .docs pre {
   padding: 1rem;


### PR DESCRIPTION
Adding some CSS to fix #381. 

For long lines that would normally cause a scroll bar to appear for the `pre` tag it now wraps the line.

![133265661-927b6619-a635-4089-843e-f79d0bf91b74](https://user-images.githubusercontent.com/353180/133275789-5374f2bc-a47c-4ad4-8baf-1da1aa18538b.png)
