### PR TITLE
💄  Background color for inline code blocks

### DIFF
--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -12,5 +12,17 @@
 }
 .docs pre code {
   color: #eeeeee;
+}
+.docs :not(pre) > code {
+  background-color: var(--g2);
+  padding: 0.3rem;
+  margin: 0;
+  display: inline;
+  overflow-wrap: break-word;
+  min-width: auto;
+  border: 1px solid var(--g3);
+  border-radius: 0.3rem;
+}
+.docs pre code, .docs :not(pre) > code  {
   font-family: Menlo, Monaco, Consolas, monospace;
 }


### PR DESCRIPTION
This PR adds some CSS to provide a background and border color for inline code blocks. I'm not married to the border, color, radius, etc but this is a good starting point.

It turns:

![Screen Shot 2021-09-15 at 15 59 47](https://user-images.githubusercontent.com/353180/133501075-b6329f40-3044-41af-a4e4-1ee868b09f32.png)

into:

![Screen Shot 2021-09-15 at 16 00 04](https://user-images.githubusercontent.com/353180/133501117-dddd12bf-5067-41c2-bc24-40ec4c1ec797.png)
