### PR TITLE
tweak inline code

### DIFF
--- a/public/css/syntax.css
+++ b/public/css/syntax.css
@@ -10,18 +10,19 @@
   white-space: pre-wrap;
   word-break: break-word;
 }
-.docs pre code {
-  color: #eeeeee;
+.docs pre {
+  /* fallback when Shiki encounters unknown syntax */
+  color: var(--g2);
+  background-color: var(--g9);
 }
 .docs :not(pre) > code {
-  background-color: var(--g2);
-  padding: 0.3rem;
+  background-color: var(--g1);
+  padding: 0.1rem 0.2rem;
   margin: 0;
   display: inline;
   overflow-wrap: break-word;
   min-width: auto;
-  border: 1px solid var(--g3);
-  border-radius: 0.3rem;
+  border-radius: 0.25rem;
 }
 .docs pre code, .docs :not(pre) > code  {
   font-family: Menlo, Monaco, Consolas, monospace;

--- a/public/static.json
+++ b/public/static.json
@@ -5,7 +5,7 @@
   "playground.js": "playground-67bb53bc87.js",
   "components/arc-tab.js": "components/arc-tab-efbcb40f74.js",
   "components/arc-viewer.js": "components/arc-viewer-53669af1ac.js",
-  "css/index.css": "css/index-1929e5c3a0.css",
+  "css/index.css": "css/index-75184ca06e.css",
   "css/styles.css": "css/styles-75499ddd30.css",
-  "css/syntax.css": "css/syntax-a1b7da5d58.css"
+  "css/syntax.css": "css/syntax-03b095eb73.css"
 }


### PR DESCRIPTION
to prevent overlap and tone down overall contrast

before:  
<img width="749" alt="Screen Shot 2021-09-16 at 11 19 39 AM" src="https://user-images.githubusercontent.com/15697/133665094-85fb142c-810c-468b-8a01-d771527608a0.png">

updated:  
<img width="1098" alt="Screen Shot 2021-09-16 at 11 29 44 AM" src="https://user-images.githubusercontent.com/15697/133665138-f6986bb5-5cb4-49f9-8aeb-f9f445f6b861.png">

I think there is still not enough contrast in `a:has(code)` but I couldn't get it to target correctly on my first pass  
<img width="563" alt="Screen Shot 2021-09-16 at 12 10 32 PM" src="https://user-images.githubusercontent.com/15697/133665234-39b6410e-9f20-41e4-91dd-189687e0132c.png">
