### PR TITLE
Swap tap-spec out for tap-min

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "spellcheck": "cross-env npx spellchecker './src/views/docs/en/**/*.md' --no-suggestions -q -d ./scripts/dictionary.js --plugins spell indefinite-article repeated-words syntax-mentions syntax-urls",
     "lint": "eslint src --fix",
     "start": "sandbox",
-    "test": "npm run spellcheck && npm run lint && tape -r esm 'test/**/*.js' | tap-spec"
+    "tape": "tape -r esm 'test/**/*.js' | tap-min",
+    "test": "npm run spellcheck && npm run lint && npm run tape"
   },
   "dependencies": {
     "@architect/architect": "^9.0.0",
@@ -56,7 +57,7 @@
     "shiki": "^0.9.10",
     "slugify": "^1.6.0",
     "spellchecker-cli": "^4.8.0",
-    "tap-spec": "^5.0.0",
+    "tap-min": "^2.0.0",
     "tape": "^5.3.0",
     "tiny-json-http": "^7.3.0",
     "vscode-textmate": "^5.4.0"


### PR DESCRIPTION
`tap-spec` is adding  3 “high” severity vulnerabilities.

This is not necessarily urgent because it’s a testing lib, but newer versions of Node do report these on each `npm install`. IMO it’s a good exercise to try it here first before other Arc repos that use `tap-spec`.

I tried several TAP reporters listed on Awesome TAP https://github.com/sindresorhus/awesome-tap
Unfortunately most with usable output (not just dots or cats), are not updated and add at least 3+ vulnerabilities.

`tap-min` ends up being a good candidate. It’s tiny, no vulnerabilities, and provides color diffs on failures. The main change from `tap-spec` is that it doesn’t list successful tests, just gives you a heads up that all is good:
<img width="982" alt="tap min reporter" src="https://user-images.githubusercontent.com/15697/133803574-44fbf00d-5b47-40da-9e2e-d9dd153f31c7.png">



I also liked `tap-mocha-reporter`. It copies/emulates the reporters that are included with Mocha. It is a part of node-tap and actively maintained https://github.com/tapjs. But I can’t get diffing in failures to work — it just tells you which test failed.
<img width="605" alt="mocha reporter" src="https://user-images.githubusercontent.com/15697/133803600-6aaeac28-a17f-462f-b064-41ce356d6cc6.png">


