### PR TITLE
Use doc title even if category isn't present in HTML title

### DIFF
--- a/scripts/dictionary.js
+++ b/scripts/dictionary.js
@@ -124,6 +124,7 @@ let dictionary = [
   'filetype',
   'FQDN',
   'frontend',
+  'Frontend',
   'globals',
   'GoDaddy',
   'hardcode',

--- a/src/views/docs/en/about/contribute.md
+++ b/src/views/docs/en/about/contribute.md
@@ -1,6 +1,6 @@
 ---
 title: Contributor guide
-category: about
+category: About
 description: How to contribute to Architect.
 ---
 

--- a/src/views/docs/en/about/mission.md
+++ b/src/views/docs/en/about/mission.md
@@ -1,6 +1,6 @@
 ---
 title: Mission
-category: about
+category: About
 description: Architect's Mission
 ---
 

--- a/src/views/docs/en/about/playground.md
+++ b/src/views/docs/en/about/playground.md
@@ -1,6 +1,6 @@
 ---
 title: Playground
-category: about
+category: About
 description: Architect's infrastructure as code playground.
 ---
 

--- a/src/views/docs/en/about/upgrade-guide.md
+++ b/src/views/docs/en/about/upgrade-guide.md
@@ -1,6 +1,6 @@
 ---
 title: Upgrade guide
-category: Get started
+category: About
 description: This document covers upgrading from previous versions of Architect
 sections:
   - Overview of Architect versions

--- a/src/views/docs/en/guides/domains/registrars/dreamhost.md
+++ b/src/views/docs/en/guides/domains/registrars/dreamhost.md
@@ -1,5 +1,6 @@
 ---
 title: Dreamhost
+category: Domain Registrars
 description: Setting up a domain name with Dreamhost
 ---
 

--- a/src/views/docs/en/guides/domains/registrars/godaddy.md
+++ b/src/views/docs/en/guides/domains/registrars/godaddy.md
@@ -1,6 +1,6 @@
 ---
 title: GoDaddy
-category: Domains
+category: Domain Registrars
 description: Setting up a domain name with GoDaddy
 ---
 

--- a/src/views/docs/en/guides/domains/registrars/namecheap.md
+++ b/src/views/docs/en/guides/domains/registrars/namecheap.md
@@ -1,5 +1,6 @@
 ---
 title: Namecheap
+category: Domain Registrars
 description: Setting up a domain name with Namecheap
 ---
 

--- a/src/views/docs/en/guides/domains/registrars/one.md
+++ b/src/views/docs/en/guides/domains/registrars/one.md
@@ -1,5 +1,6 @@
 ---
 title: One
+category: Domain Registrars
 description: Setting up a domain name with One
 ---
 

--- a/src/views/docs/en/guides/domains/registrars/route53-and-cloudfront.md
+++ b/src/views/docs/en/guides/domains/registrars/route53-and-cloudfront.md
@@ -1,5 +1,6 @@
 ---
 title: Route53 & CloudFront
+category: Domain Registrars
 description: Setting up a domain name with Route53 and CloudFront
 ---
 

--- a/src/views/docs/en/guides/domains/registrars/route53.md
+++ b/src/views/docs/en/guides/domains/registrars/route53.md
@@ -1,5 +1,6 @@
 ---
 title: Route53
+category: Domain Registrars
 description: Setting up a domain name with Route53
 ---
 

--- a/src/views/docs/en/guides/extend/add-a-custom-domain.md
+++ b/src/views/docs/en/guides/extend/add-a-custom-domain.md
@@ -1,5 +1,6 @@
 ---
 title: Assigning a domain name to your app
+category: Extend
 description: 160 (or fewer) character description of this document!
 sections:
   - Overview
@@ -24,7 +25,7 @@ DNS is how you assign a domain name to a deployed app. This guide lists ways to 
   - [DNS with Route53](#dns-with-route53)
   - [Starting over](#starting-over)
   - [The manual way](the-manual-way)
- 
+
 
 ## Setup
 
@@ -62,7 +63,7 @@ Run `npx dns` and follow the instructions. The process is:
 
 The certificate, CloudFront distributions and DNS records in general can take time to propagate. Be Zen! Running and re-running `npx dns` is safe.
 
-## DNS with Route53 
+## DNS with Route53
 
 **Opt-in, but recommended!**
 

--- a/src/views/docs/en/guides/extend/custom-cloudformation.md
+++ b/src/views/docs/en/guides/extend/custom-cloudformation.md
@@ -1,5 +1,6 @@
 ---
 title: Custom CloudFormation
+category: Extend
 description: How to use Architect Macros to define or modify resources with CloudFormation
 ---
 

--- a/src/views/docs/en/guides/extend/custom-iam-roles.md
+++ b/src/views/docs/en/guides/extend/custom-iam-roles.md
@@ -1,5 +1,6 @@
 ---
 title: Custom IAM roles
+category: Extend
 description: Defining custom execution roles for individual Lambda functions
 sections:
   - Overview
@@ -7,13 +8,13 @@ sections:
 
 ## Overview
 
-[IAM, Identity and Access Management,](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html) is a feature of AWS which controls how AWS resources can be accessed by users. IAM roles use policies to define the permissions for a given resource. For example, a Lambda function will assume an IAM role during execution that tells AWS what other resources that Lambda has access to and what operations it is allowed to perform. 
+[IAM, Identity and Access Management,](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction.html) is a feature of AWS which controls how AWS resources can be accessed by users. IAM roles use policies to define the permissions for a given resource. For example, a Lambda function will assume an IAM role during execution that tells AWS what other resources that Lambda has access to and what operations it is allowed to perform.
 
-Imagine that IAM roles represent different hats that a user puts on in order to perform an operation. You would put on your "Read-Only hat" to limit the scope of a Lambda execution to just reading a table and deny write access. 
+Imagine that IAM roles represent different hats that a user puts on in order to perform an operation. You would put on your "Read-Only hat" to limit the scope of a Lambda execution to just reading a table and deny write access.
 
 You can define a custom IAM role for your Lambda Function with an `.arc-config` file in the Lambda function code folder.
 
-By default, your functions are executed with a least privileged role, which means that it only has access to the services it needs and nothing else. 
+By default, your functions are executed with a least privileged role, which means that it only has access to the services it needs and nothing else.
 
 If we take a look at the IAM policy for a Lambda function that is created by Architect, we can see that it can be executed with only the ability to create logs in CloudWatch.
 
@@ -47,6 +48,6 @@ memory 512mb
 concurrency 1
 policies arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
 ```
-ARNs, Amazon Resource Names, are globally unique identifiers to specify a resource. You can create new policies in the AWS console or use Managed Policies that are made available by AWS. 
+ARNs, Amazon Resource Names, are globally unique identifiers to specify a resource. You can create new policies in the AWS console or use Managed Policies that are made available by AWS.
 
 [Check out the AWS documentation for more information on Managed Policies](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_managed-vs-inline.html#aws-managed-policies)

--- a/src/views/docs/en/guides/extend/eject-to-cloudformation.md
+++ b/src/views/docs/en/guides/extend/eject-to-cloudformation.md
@@ -1,6 +1,6 @@
 ---
 title: Ejecting to CloudFormation
-category: Tutorials
+category: Extend
 description: Ejecting to CloudFormation
 sections:
   - Overview
@@ -9,7 +9,7 @@ sections:
 
 ## Overview
 
-Need to install @architect/architect 
+Need to install @architect/architect
 
 And then in the project directory run arc package
 

--- a/src/views/docs/en/guides/extend/plugins.md
+++ b/src/views/docs/en/guides/extend/plugins.md
@@ -1,5 +1,6 @@
 ---
 title: Plugins (beta)
+category: Extend
 description: How to extend Architect using lifecycle hooks
 ---
 

--- a/src/views/docs/en/guides/frontend/cdn.md
+++ b/src/views/docs/en/guides/frontend/cdn.md
@@ -1,5 +1,6 @@
 ---
 title: CDN
+category: Frontend
 description: Content delivery network (CDN) with AWS CloudFront
 sections:
   - Overview

--- a/src/views/docs/en/guides/frontend/cors.md
+++ b/src/views/docs/en/guides/frontend/cors.md
@@ -1,5 +1,6 @@
 ---
 title: Implementing CORS
+category: Frontend
 ---
 
 Cross-origin resource sharing (CORS) is a mechanism that that uses additional HTTP headers to tell browsers to give a web application running at one origin access resources from another domain outside the domain from which the first resource was served. A web page may freely embed cross-origin images, stylesheets, scripts, iframes, and videos.
@@ -40,7 +41,7 @@ async function handler (req) {
 
 ## Restricting Domains
 
-You can restrict domains within your Lambda function code. 
+You can restrict domains within your Lambda function code.
 
 Continuing from the `/api` endpoint, your API might operate differently based on the request's domain of origin:
 

--- a/src/views/docs/en/guides/frontend/http-functions.md
+++ b/src/views/docs/en/guides/frontend/http-functions.md
@@ -1,5 +1,6 @@
 ---
 title: HTTP functions
+category: Frontend
 description: HTTP Functions are the building blocks of the modern web app
 sections:
   - Overview

--- a/src/views/docs/en/guides/frontend/middleware.md
+++ b/src/views/docs/en/guides/frontend/middleware.md
@@ -1,6 +1,6 @@
 ---
 title: Cloud function middleware
-category: Tutorials
+category: Frontend
 description: Short Tutorial showing both async/await and callback-style runtime helpers to modify request objects.
 sections:
   - Overview

--- a/src/views/docs/en/guides/frontend/sessions.md
+++ b/src/views/docs/en/guides/frontend/sessions.md
@@ -1,5 +1,6 @@
 ---
 title: HTTP & WebSocket sessions
+category: Frontend
 description: 160 (or fewer) character description of this document!
 sections:
   - Overview

--- a/src/views/docs/en/guides/frontend/single-page-apps.md
+++ b/src/views/docs/en/guides/frontend/single-page-apps.md
@@ -1,5 +1,6 @@
 ---
 title: Single page apps
+category: Frontend
 description: Static and dynamic API endpoints coexisting at the same origin
 sections:
   - Overview

--- a/src/views/docs/en/guides/frontend/static-assets.md
+++ b/src/views/docs/en/guides/frontend/static-assets.md
@@ -1,5 +1,6 @@
 ---
 title: Static assets
+category: Frontend
 description: Architect projects support text and binary static assets such as images, styles, and scripts.
 ---
 
@@ -22,7 +23,7 @@ folder dist
 
 ### `fingerprint`
 
-Fingerprinting adds a unique SHA to a file name based on the file content before uploading to S3. The file can then be cached effectively forever. Whenever the contents of the file changes so does the SHA invalidating the cache. 
+Fingerprinting adds a unique SHA to a file name based on the file content before uploading to S3. The file can then be cached effectively forever. Whenever the contents of the file changes so does the SHA invalidating the cache.
 
 Enable fingerprinting:
 

--- a/src/views/docs/en/guides/frontend/web-sockets.md
+++ b/src/views/docs/en/guides/frontend/web-sockets.md
@@ -1,6 +1,6 @@
 ---
 title: Adding WebSockets to your app
-category: Tutorials
+category: Frontend
 description: Add real-time connections between clients with serverless functions.
 sections:
   - Overview
@@ -10,10 +10,10 @@ sections:
 
 ## Overview
 
-The [`@ws`](/docs/en/reference/arc-pragmas/@ws) primitive creates a WebSocket endpoint and stateless handler functions: 
+The [`@ws`](/docs/en/reference/arc-pragmas/@ws) primitive creates a WebSocket endpoint and stateless handler functions:
 
 - **`connect`**: This handler function is used when a client first connects to your WebSocket API.
-- **`disconnect`**: This handler function is used when a client disconnects from your API. 
+- **`disconnect`**: This handler function is used when a client disconnects from your API.
 - **`default`**: Used when the route selection expression produces a value that does not match any of the other route keys in your API routes. This can be used, for example, to implement a generic error handling mechanism.
 
 These handler functions allow you to hold a long lived state connection between two different endpoints.

--- a/src/views/docs/en/guides/frontend/websocket-functions.md
+++ b/src/views/docs/en/guides/frontend/websocket-functions.md
@@ -1,5 +1,6 @@
 ---
 title: WebSocket functions
+category: Frontend
 description: WebSockets provide a persistent connection between a client and a server.
 sections:
   - Overview

--- a/src/views/docs/en/reference/app.arc/app.md
+++ b/src/views/docs/en/reference/app.arc/app.md
@@ -1,5 +1,6 @@
 ---
 title: '@app'
+category: app.arc
 description: Define the application namespace
 ---
 

--- a/src/views/docs/en/reference/app.arc/aws.md
+++ b/src/views/docs/en/reference/app.arc/aws.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws'
+category: app.arc
 description: Define AWS specific configuration.
 ---
 

--- a/src/views/docs/en/reference/app.arc/events.md
+++ b/src/views/docs/en/reference/app.arc/events.md
@@ -1,5 +1,6 @@
 ---
 title: '@events'
+category: app.arc
 ---
 
  Define SNS topics with Lambda handler functions.

--- a/src/views/docs/en/reference/app.arc/http.md
+++ b/src/views/docs/en/reference/app.arc/http.md
@@ -1,5 +1,6 @@
 ---
 title: '@http'
+category: app.arc
 description: Define HTTP routes
 ---
 

--- a/src/views/docs/en/reference/app.arc/indexes.md
+++ b/src/views/docs/en/reference/app.arc/indexes.md
@@ -1,5 +1,6 @@
 ---
 title: '@indexes'
+category: app.arc
 description: Define DynamoDB table global secondary indexes.
 ---
 

--- a/src/views/docs/en/reference/app.arc/macros.md
+++ b/src/views/docs/en/reference/app.arc/macros.md
@@ -1,5 +1,6 @@
 ---
 title: '@macro'
+category: app.arc
 description: Extend Architect app functionality
 ---
 

--- a/src/views/docs/en/reference/app.arc/proxy.md
+++ b/src/views/docs/en/reference/app.arc/proxy.md
@@ -1,5 +1,6 @@
 ---
 title: '@proxy'
+category: app.arc
 description: Define a forwarding URL
 ---
 

--- a/src/views/docs/en/reference/app.arc/queues.md
+++ b/src/views/docs/en/reference/app.arc/queues.md
@@ -1,5 +1,6 @@
 ---
 title: '@queues'
+category: app.arc
 description: Define SQS topics
 ---
 

--- a/src/views/docs/en/reference/app.arc/scheduled.md
+++ b/src/views/docs/en/reference/app.arc/scheduled.md
@@ -1,5 +1,6 @@
 ---
 title: '@scheduled'
+category: app.arc
 description: Define EventBridge schedule expressions
 ---
 

--- a/src/views/docs/en/reference/app.arc/shared.md
+++ b/src/views/docs/en/reference/app.arc/shared.md
@@ -1,5 +1,6 @@
 ---
 title: '@shared'
+category: app.arc
 description: Configure src/shared code
 ---
 

--- a/src/views/docs/en/reference/app.arc/static.md
+++ b/src/views/docs/en/reference/app.arc/static.md
@@ -1,5 +1,6 @@
 ---
 title: '@static'
+category: app.arc
 description: Define S3 bucket
 ---
 

--- a/src/views/docs/en/reference/app.arc/tables.md
+++ b/src/views/docs/en/reference/app.arc/tables.md
@@ -1,5 +1,6 @@
 ---
 title: '@tables'
+category: app.arc
 description: Define DynamoDB tables
 ---
 

--- a/src/views/docs/en/reference/app.arc/views.md
+++ b/src/views/docs/en/reference/app.arc/views.md
@@ -1,5 +1,6 @@
 ---
 title: '@views'
+category: app.arc
 description: Share view code across `@http` functions
 ---
 

--- a/src/views/docs/en/reference/app.arc/ws.md
+++ b/src/views/docs/en/reference/app.arc/ws.md
@@ -1,5 +1,6 @@
 ---
 title: '@ws'
+category: app.arc
 description: Define WebSocket endpoints
 ---
 

--- a/src/views/docs/en/reference/cli/deploy.md
+++ b/src/views/docs/en/reference/cli/deploy.md
@@ -1,5 +1,6 @@
 ---
 title: arc deploy
+category: CLI
 description: Architect deploy is a module to deploy SAM and CloudFormation templates to an AWS account
 sections:
   - Overview
@@ -18,7 +19,7 @@ arc deploy [production|static|direct]
 ## Flags
 
 - `[--no-hydrate]` Do not automatically run `npm`, `bundle` or `pip`
-- `[dirty, --dirty, -d]` Overwrite staging Lambda with local source. A faster way to deploy and test small changes to individual functions without redeploying an entire stack. 
+- `[dirty, --dirty, -d]` Overwrite staging Lambda with local source. A faster way to deploy and test small changes to individual functions without redeploying an entire stack.
 - `[--dry-run]` Creates a CloudFormation template but does not deploy it. A dry-run allows you to check the CloudFormation and SAM output before deploying the actual stack.
 - `[production, --production, -p]` Deploys a CloudFormation stack to a production stack.
 - `[prune, --prune]` Remove assets not present in the local static folder.

--- a/src/views/docs/en/reference/cli/destroy.md
+++ b/src/views/docs/en/reference/cli/destroy.md
@@ -1,5 +1,6 @@
 ---
 title: arc destroy
+category: CLI
 description: CLI destroy command for removing Architect application
 ---
 

--- a/src/views/docs/en/reference/cli/env.md
+++ b/src/views/docs/en/reference/cli/env.md
@@ -1,5 +1,6 @@
 ---
 title: arc env
+category: CLI
 description: Read and write environment variables for Lambda functions.
 ---
 

--- a/src/views/docs/en/reference/cli/hydrate.md
+++ b/src/views/docs/en/reference/cli/hydrate.md
@@ -1,5 +1,6 @@
 ---
 title: hydrate
+category: CLI
 description: Quickly install and update dependencies for all functions in the src directory.
 ---
 
@@ -62,8 +63,8 @@ Copies shared code (from `src/shared` and `src/views`) into all Functions.
 
 ### `arc hydrate`
 
-- `arc hydrate` runs `npm i` 
-- `arc hydrate update` runs `npm update` 
+- `arc hydrate` runs `npm i`
+- `arc hydrate update` runs `npm update`
 
 > ⚠️ Note: this operation can take time to complete depending on how many Lambdas you have and how many modules they require.
 

--- a/src/views/docs/en/reference/cli/init.md
+++ b/src/views/docs/en/reference/cli/init.md
@@ -1,5 +1,6 @@
 ---
 title: arc init
+category: CLI
 description: Scaffold new resources found in the app.arc file
 ---
 

--- a/src/views/docs/en/reference/cli/logs.md
+++ b/src/views/docs/en/reference/cli/logs.md
@@ -1,5 +1,6 @@
 ---
 title: arc logs
+category: CLI
 description: Read or clears Lambda function logs.
 ---
 

--- a/src/views/docs/en/reference/cli/package.md
+++ b/src/views/docs/en/reference/cli/package.md
@@ -1,6 +1,7 @@
 ---
 title: arc package
-description: Generate AWS SAM template based on the current app.arc 
+category: CLI
+description: Generate AWS SAM template based on the current app.arc
 ---
 
 Transform `app.arc` into `sam.json`. [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/what-is-sam.html) can be deployed with the AWS CLI.

--- a/src/views/docs/en/reference/cli/sandbox.md
+++ b/src/views/docs/en/reference/cli/sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: arc sandbox
+category: CLI
 description: Local development sandbox.
 ---
 

--- a/src/views/docs/en/reference/config.arc/aws.md
+++ b/src/views/docs/en/reference/config.arc/aws.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws'
+category: config.arc
 description: Lambda function configuration
 ---
 

--- a/src/views/docs/en/reference/config.arc/concurrency.md
+++ b/src/views/docs/en/reference/config.arc/concurrency.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws concurrency'
+category: config.arc
 description: Lambda function configuration
 ---
 

--- a/src/views/docs/en/reference/config.arc/layers.md
+++ b/src/views/docs/en/reference/config.arc/layers.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws layers'
+category: config.arc
 description: Lambda function configuration
 ---
 
@@ -25,4 +26,4 @@ layers
   arn:aws:lambda:us-east-1:145266761615:layer:pandoc:1
 ```
 
-> Tip: find [awesome layers](https://github.com/mthenw/awesome-layers) 
+> Tip: find [awesome layers](https://github.com/mthenw/awesome-layers)

--- a/src/views/docs/en/reference/config.arc/memory.md
+++ b/src/views/docs/en/reference/config.arc/memory.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws memory'
+category: config.arc
 description: Lambda function configuration
 ---
 

--- a/src/views/docs/en/reference/config.arc/policies.md
+++ b/src/views/docs/en/reference/config.arc/policies.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws policies'
+category: config.arc
 description: Lambda function `policies`
 ---
 

--- a/src/views/docs/en/reference/config.arc/runtime.md
+++ b/src/views/docs/en/reference/config.arc/runtime.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws runtime'
+category: config.arc
 description: Lambda function configuration
 ---
 

--- a/src/views/docs/en/reference/config.arc/timeout.md
+++ b/src/views/docs/en/reference/config.arc/timeout.md
@@ -1,5 +1,6 @@
 ---
 title: '@aws timeout'
+category: config.arc
 description: Lambda function configuration
 ---
 

--- a/src/views/docs/en/reference/prefs.arc/.env.md
+++ b/src/views/docs/en/reference/prefs.arc/.env.md
@@ -1,5 +1,6 @@
 ---
 title: '.env'
+category: prefs.arc
 description: Sandbox environment variables
 ---
 

--- a/src/views/docs/en/reference/prefs.arc/create.md
+++ b/src/views/docs/en/reference/prefs.arc/create.md
@@ -1,5 +1,6 @@
 ---
 title: '@create'
+category: prefs.arc
 description: Sandbox environment variables
 ---
 
@@ -9,7 +10,7 @@ Preferences for resource creation with `arc init`.
 
 ## `autocreate`
 
-By adding the `@create` pragma to your preferences file and specifying `autocreate true`, you can enable `arc sandbox`, `arc deploy`, and other workflows to automatically run `arc init` to create boilerplate Lambda handlers and static assets if they do not exist. 
+By adding the `@create` pragma to your preferences file and specifying `autocreate true`, you can enable `arc sandbox`, `arc deploy`, and other workflows to automatically run `arc init` to create boilerplate Lambda handlers and static assets if they do not exist.
 
 ```arc
 @create

--- a/src/views/docs/en/reference/prefs.arc/env.md
+++ b/src/views/docs/en/reference/prefs.arc/env.md
@@ -1,5 +1,6 @@
 ---
 title: '@env'
+category: prefs.arc
 description: Sandbox environment variables
 ---
 

--- a/src/views/docs/en/reference/prefs.arc/sandbox-startup.md
+++ b/src/views/docs/en/reference/prefs.arc/sandbox-startup.md
@@ -1,5 +1,6 @@
 ---
 title: '@sandbox-startup'
+category: prefs.arc
 description: Sandbox scripts
 ---
 

--- a/src/views/docs/en/reference/prefs.arc/sandbox.md
+++ b/src/views/docs/en/reference/prefs.arc/sandbox.md
@@ -1,5 +1,6 @@
 ---
 title: '@sandbox'
+category: prefs.arc
 description: Sandbox environment variables
 ---
 

--- a/src/views/docs/en/reference/runtime/deno.md
+++ b/src/views/docs/en/reference/runtime/deno.md
@@ -1,5 +1,6 @@
 ---
 title: Deno
+category: Runtime
 description: Deno runtime support
 ---
 

--- a/src/views/docs/en/reference/runtime/node.js.md
+++ b/src/views/docs/en/reference/runtime/node.js.md
@@ -1,5 +1,6 @@
 ---
 title: Node.js
+category: Runtime
 description: Node.js runtime helpers
 ---
 

--- a/src/views/docs/en/reference/runtime/python.md
+++ b/src/views/docs/en/reference/runtime/python.md
@@ -1,5 +1,6 @@
 ---
 title: Python
+category: Runtime
 description: Python runtime support
 ---
 

--- a/src/views/docs/en/reference/runtime/ruby.md
+++ b/src/views/docs/en/reference/runtime/ruby.md
@@ -1,5 +1,6 @@
 ---
 title: Ruby
+category: Runtime
 description: Ruby runtime support
 ---
 

--- a/src/views/modules/document/head.js
+++ b/src/views/modules/document/head.js
@@ -1,9 +1,12 @@
 export default function Head (props = {}) {
   let { category, description, title } = props
-  let fullTitle = category && title
-    ? `${category} > ${title} - Architect documentation`
-    : 'Architect documentation'
   let descriptionContent = description || 'Architect documentation'
+  let fullTitle = ''
+  if (category && title)
+    fullTitle += `${category} > ${title} - `
+  else if (title)
+    fullTitle += `${title} - `
+  fullTitle += 'Architect documentation'
 
   return `
 <head>


### PR DESCRIPTION
Fixes #380 
Use doc title even if category isn't present in HTML title (bottom of the diff)
Also, add missing category front matter (the rest of the diff)

(This helps toward my goal of being in all files' git blame. kidding!)