### PR TITLE
Issue Docs don't agree on default node runtime #399

### DIFF
--- a/src/views/docs/en/guides/backend/events-and-queues.md
+++ b/src/views/docs/en/guides/backend/events-and-queues.md
@@ -183,7 +183,7 @@ From the terminal, run `arc deploy --dry-run` and take a look at `sam.yaml` in t
       "Properties": {
         "Handler": "index.handler",
         "CodeUri": "./src/scheduled/daily",
-        "Runtime": "nodejs12.x",
+        "Runtime": "nodejs14.x",
         "MemorySize": 1152,
         "Timeout": 5,
         "Environment": {

--- a/src/views/docs/en/guides/extend/custom-iam-roles.md
+++ b/src/views/docs/en/guides/extend/custom-iam-roles.md
@@ -43,7 +43,7 @@ Here's how you would add a custom role to your Lambda with a `.arc-config` file.
 // src/http/get-orders/.arc-config
 
 @aws
-runtime nodejs12.x
+runtime nodejs14.x
 memory 512mb
 concurrency 1
 policies arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess

--- a/src/views/docs/en/guides/get-started/detailed-aws-setup.md
+++ b/src/views/docs/en/guides/get-started/detailed-aws-setup.md
@@ -4,7 +4,7 @@ category: Get started
 description: Setting up and installing Architect.
 ---
 
-> To work locally all you need is [Node](https://nodejs.org), any additional [supported runtimes](#supported-runtimes) you plan to use, and the [Architect CLI](#install-architect). 
+> To work locally all you need is [Node](https://nodejs.org), any additional [supported runtimes](#supported-runtimes) you plan to use, and the [Architect CLI](#install-architect).
 
 ## AWS deployment requirements
 
@@ -31,8 +31,8 @@ Architect supports the following runtime versions:
 To change the default runtime add it to the `app.arc` under the `@aws` pragma:
 
 ```arc
-# Valid runtimes: 
-# - nodejs12.x (default)
+# Valid runtimes:
+# - nodejs14.x (default)
 # - deno
 # - python3.8
 # - ruby2.5

--- a/src/views/docs/en/reference/app.arc/aws.md
+++ b/src/views/docs/en/reference/app.arc/aws.md
@@ -14,7 +14,7 @@ Define AWS specific configuration.
     - Can also be specified in `AWS_PROFILE` environment variable
     - Required to deploy to AWS
   - `runtime`: Lambda runtime, can be one of:
-    - `nodejs12.x`, `nodejs10.x`, `deno`, `python3.8`, `python3.7`, `python3.6`, `go1.x`, `ruby2.7`, `ruby2.5`, `dotnetcore3.1`, `dotnetcore2.1`, `java11`, `java8`
+    - `nodejs14.x`, `nodejs12.x`, `deno`, `python3.8`, `python3.7`, `python3.6`, `go1.x`, `ruby2.7`, `ruby2.5`, `dotnetcore3.1`, `dotnetcore2.1`, `java11`, `java8`
   - **`bucket`**: bucket (in same region) for CloudFormation deployment artifacts
     - If not specified, a secure deployment bucket will be auto-created for your app
   - `apigateway`: API Gateway API type, can be one of:

--- a/src/views/docs/en/reference/config.arc/aws.md
+++ b/src/views/docs/en/reference/config.arc/aws.md
@@ -6,7 +6,7 @@ description: Lambda function configuration
 
 Configure individual Lambda function properties (e.g. `src/http/get-index/config.arc`).
 
-- `runtime` - Officially supported: one of `nodejs12.x` (default), `deno`, `python3.7`, `python3.6`, or `ruby.5`, etc.
+- `runtime` - Officially supported: one of `nodejs14.x` (default), `deno`, `python3.7`, `python3.6`, or `ruby.5`, etc.
   - Also configurable, but not officially supported by Architect: `java8`, `go1.x`, `dotnetcore2.1`
 - `memory` - number, between `128`MB and `3008`MB in 64 MB increments
   - Memory size also directly correlates with CPU speed; higher memory levels are available in more capable Lambda clusters


### PR DESCRIPTION
Fix for Issue #399 

Updates default nodejs runtime to 14.x in docs.