### PR TITLE
link to static assets guide from app.arc static reference

### DIFF
--- a/src/views/docs/en/guides/backend/persist-data.md
+++ b/src/views/docs/en/guides/backend/persist-data.md
@@ -568,7 +568,7 @@ module.exports = async function requireLogin(request) {
 }
 ```
 
-> 🏄‍♀️ Read more about [middleware](/docs/en/guides/tutorials/cloud-function-middleware) here.
+> 🏄‍♀️  Read more about [middleware](/docs/en/guides/tutorials/cloud-function-middleware) here.
 
 ---
 
@@ -940,5 +940,5 @@ let deleteNote = async function route(request) {
 exports.handler = arc.middleware(requireLogin, deleteNote)
 ```
 
-> 🎩 Tip: `data._db` and `data._doc` return instances of `DynamoDB` and `DynamoDB.DocumentClient` for directly accessing your data; use `data._name` to resolve the table names with the app name and environment prefix.
+> 🎩  Tip: `data._db` and `data._doc` return instances of `DynamoDB` and `DynamoDB.DocumentClient` for directly accessing your data; use `data._name` to resolve the table names with the app name and environment prefix.
 

--- a/src/views/docs/en/guides/extend/add-a-custom-domain.md
+++ b/src/views/docs/en/guides/extend/add-a-custom-domain.md
@@ -84,7 +84,7 @@ If something goes wrong you can destroy the generated resources and re-create.
 - `npx dns nuke` destroys the certificate and CloudFront domain distributions
 - `ARC_NUKE=route53 npx dns nuke` destroys the certificate, CloudFront domain distributions, the Hosted Zone, certificate validation CNAME and Alias records
 
-> 🤷🏽‍♀️ DNS propagation can take time: have patience!
+> 🤷🏽‍♀️  DNS propagation can take time: have patience!
 
 
 ## The manual way
@@ -98,7 +98,7 @@ If you _really_ want to manually configure DNS you can follow these guides below
 
 Follow these instructions to manually configure Route 53 to serve your application from your domain. As a friendly reminder: the `arc` happy path for using Route 53 remains the [`@domain`](/en/reference/arc-pragmas/@domain) section (per the instructions above).
 
-> ⛳️ Tip: These instructions will serve your app's production environment; if you'd also like a friendly URL for your staging environment (i.e. `staging.foo.com`), follow steps 10-15 below a second time, swapping `production` values for `staging` values.
+> ⛳️  Tip: These instructions will serve your app's production environment; if you'd also like a friendly URL for your staging environment (i.e. `staging.foo.com`), follow steps 10-15 below a second time, swapping `production` values for `staging` values.
 
 1. Sign into the AWS Console, head to the Route 53 service, and click on **Hosted Zones**
 2. Create a **Hosted Zone**

--- a/src/views/docs/en/guides/extend/plugins.md
+++ b/src/views/docs/en/guides/extend/plugins.md
@@ -4,7 +4,7 @@ category: Extend
 description: How to extend Architect using lifecycle hooks
 ---
 
-> ⚠️ NOTE: Plugin support was added in version 8.6.0, is currently in beta, the interface is subject to change and only supports Node.js
+> ⚠️  NOTE: Plugin support was added in version 8.6.0, is currently in beta, the interface is subject to change and only supports Node.js
 
 Using [`@macros`][macros] allows you to augment the Architect-generated CloudFormation before deployment. However, augmenting CloudFormation may not be sufficient for certain extensions. For example, if you want to extend Architect with:
 
@@ -189,7 +189,7 @@ All arguments arrive as a bag of options with the following properties:
 
 This method should always return an object. Each property on the object represents a variable name, and the value for each property contains the variable value.
 
-> 🏌️‍♀️ Protip: When this method is invoked in a pre-deploy context, acceptable values for the variables include CloudFormation JSON. This is essential to expose CloudFormation-managed infrastructure; see the example below.
+> 🏌️‍♀️  Protip: When this method is invoked in a pre-deploy context, acceptable values for the variables include CloudFormation JSON. This is essential to expose CloudFormation-managed infrastructure; see the example below.
 
 #### Example `variables` implementation
 

--- a/src/views/docs/en/guides/frontend/http-functions.md
+++ b/src/views/docs/en/guides/frontend/http-functions.md
@@ -99,7 +99,7 @@ All HTTP Functions begin with `/`, and can include letters, numbers, and slashes
 
 Importantly and uniquely, you can also use URL parameters to build dynamic paths – more on that below.
 
-> ✨ Tip: It's possible to have multiple HTTP methods respond from the same path. For example: `get /contact-us` and `post /contact-us` is totally valid, as you'd expect.
+> ✨  Tip: It's possible to have multiple HTTP methods respond from the same path. For example: `get /contact-us` and `post /contact-us` is totally valid, as you'd expect.
 
 ### Greedy root
 

--- a/src/views/docs/en/guides/frontend/single-page-apps.md
+++ b/src/views/docs/en/guides/frontend/single-page-apps.md
@@ -43,7 +43,7 @@ staging spa-stage-bukkit
 production spa-prod-bukkit
 ```
 
-> 👉🏽 Note: S3 buckets are global to all of AWS so you may need to try a few different names!
+> 👉🏽  Note: S3 buckets are global to all of AWS so you may need to try a few different names!
 
 ## Proxy Public
 

--- a/src/views/docs/en/guides/frontend/static-assets.md
+++ b/src/views/docs/en/guides/frontend/static-assets.md
@@ -4,7 +4,7 @@ category: Frontend
 description: Architect projects support text and binary static assets such as images, styles, and scripts.
 ---
 
-Architect projects support text and binary static assets such as images, styles, and scripts. By default `@static` assets live in the `/public` folder locally and an S3 bucket once deployed.
+Architect projects support text and binary static assets such as images, styles, and scripts. By default `@static` assets live locally in the `/public` folder at the root of your project and in an S3 bucket once deployed.
 
 ## `@static` configuration
 

--- a/src/views/docs/en/guides/frontend/web-sockets.md
+++ b/src/views/docs/en/guides/frontend/web-sockets.md
@@ -179,4 +179,4 @@ The `ws-default` Lambda will be the main event bus for web socket events. The `e
 
 The `ws-disconnect` Lambda is used to cleanup any records of `event.requestContext.connectionId`.
 
-> 🔭 Find [the example repo on GitHub](https://github.com/architect/arc-example-ws).
+> 🔭  Find [the example repo on GitHub](https://github.com/architect/arc-example-ws).

--- a/src/views/docs/en/reference/app.arc/static.md
+++ b/src/views/docs/en/reference/app.arc/static.md
@@ -17,7 +17,6 @@ Configure the static asset S3 bucket.
 
 This `app.arc` file defines a static bucket:
 
-
 <arc-viewer default-tab=arc>
 <div slot=contents class=bg-g4>
 
@@ -98,6 +97,8 @@ static:
 
 </div>
 </arc-viewer>
+
+> 🔖 The [Frontend Static assets guide](/docs/en/guides/frontend/static-assets) has more information on how to use static assets in your Architect project.
 
 ## Deployment
 

--- a/src/views/docs/en/reference/app.arc/static.md
+++ b/src/views/docs/en/reference/app.arc/static.md
@@ -98,7 +98,7 @@ static:
 </div>
 </arc-viewer>
 
-> 🔖 The [Frontend Static assets guide](/docs/en/guides/frontend/static-assets) has more information on how to use static assets in your Architect project.
+> 📜  The [Frontend Static assets guide](/docs/en/guides/frontend/static-assets) has more information on how to use static assets in your Architect project.
 
 ## Deployment
 

--- a/src/views/docs/en/reference/cli/hydrate.md
+++ b/src/views/docs/en/reference/cli/hydrate.md
@@ -66,7 +66,7 @@ Copies shared code (from `src/shared` and `src/views`) into all Functions.
 - `arc hydrate` runs `npm i`
 - `arc hydrate update` runs `npm update`
 
-> ⚠️ Note: this operation can take time to complete depending on how many Lambdas you have and how many modules they require.
+> ⚠️  Note: this operation can take time to complete depending on how many Lambdas you have and how many modules they require.
 
 ## Flags
 


### PR DESCRIPTION
Addresses #248 by linking from app.arc > @static to the frontend guide on Static Assets. Also clarifies that the `/public` directory lives at the project root.
