### PR TITLE
add test for broken links with linkinator

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -1,0 +1,61 @@
+name: "Arc.codes Link Checker"
+
+on: [ pull_request ]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    # Setup
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        node-version: [ 14.x, 16.x ]
+        os: [ ubuntu-latest ]
+
+    # Go
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Env
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Git ref:    ${{ github.ref }}"
+          echo "GH actor:   ${{ github.actor }}"
+          echo "SHA:        ${{ github.sha }}"
+          VER=`node --version`; echo "Node ver:   $VER"
+          VER=`npm --version`; echo "npm ver:    $VER"
+
+      - name: Install
+        run: npm install
+
+      - name: Vendor dist files
+        run: npm run dist
+
+      - name: Hydrate
+        run: npx arc hydrate
+        env:
+          CI: true
+
+      - name: check links
+        run: npm run link-checker
+        env:
+          CI: true
+
+      - name: Notify
+        uses: sarisia/actions-status-discord@v1
+        # Only fire alert once
+        if: github.ref == 'refs/heads/main' && failure()
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          title: "link checker"
+          color: 0x222222
+          username: GitHub Actions

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@architect/eslint-config": "^2.0.1",
     "@architect/spellcheck-dictionary": "github:architect/spellcheck-dictionary",
     "eslint": "^8.1.0",
+    "linkinator": "^2.14.5",
     "spellchecker-cli": "^4.8.0",
     "tap-spec": "^5.0.0",
     "tape": "^5.3.1",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "dist": "./scripts/dist.sh",
     "spellcheck": "npx spellchecker --config ./scripts/spellcheckerrc.json",
+    "link-checker": "node ./scripts/link-checker-test.js | tap-spec",
     "lint": "eslint src --fix",
     "start": "sandbox",
     "test:unit:frontend": "tape -r esm 'test/frontend/**/*.js' | tap-spec",

--- a/scripts/link-checker-test.js
+++ b/scripts/link-checker-test.js
@@ -1,0 +1,40 @@
+let link = require('linkinator')
+let test = require('tape')
+let sandbox = require('@architect/sandbox')
+let { currentRoot } = require('../src/shared/redirect-map')
+
+const host = 'http://localhost:3333'
+const root = `${host}${currentRoot}`
+
+test('find broken links', async (t) => {
+  await sandbox.start({ quiet: true })
+  t.pass(`sandbox started at ${host}`)
+
+  const checker = new link.LinkChecker()
+
+  checker.on('link', result => {
+    if (result.state === 'BROKEN')
+      console.log(`${result.status} ${result.url} from ${result.parent}`)
+  })
+
+  const result = await checker.check({
+    concurrency: 5, // default of 100 causes functions to exceed 5s timeout
+    path: root,
+    recurse: true,
+    linksToSkip: [
+      'https://www.godaddy.com', // GoDaddy 403s crawlers
+      'https://github.com/architect/arc.codes/edit/' // skip all the "Edit on GitHub" links
+    ],
+  })
+
+  const brokenCount = result.links.filter(x => x.state === 'BROKEN').length
+  const okCount = result.links.filter(x => x.state === 'OK').length
+
+  t.ok(brokenCount === 0, `${brokenCount} broken link${brokenCount > 1 || brokenCount === 0 ? 's' : ''}`)
+  t.pass(`${okCount} working link${okCount > 1 || okCount === 0 ? 's' : ''}`)
+
+  await sandbox.end()
+  t.pass('sandbox ended')
+
+  t.end()
+})

--- a/src/shared/redirect-map.js
+++ b/src/shared/redirect-map.js
@@ -239,10 +239,7 @@ const permanentRedirects = {
   '/reference/data-delete': '/docs/en/reference/runtime-helpers/node.js#arc.tables',
 }
 
-exports.tempRedirects = tempRedirects
-exports.permanentRedirects = permanentRedirects
-
-exports.redirect = async function redirect (req) {
+async function redirect (req) {
   const reqPath = req.requestContext.http.path
   const isGet = req.requestContext.http.method.toLowerCase() === 'get'
 
@@ -262,4 +259,11 @@ exports.redirect = async function redirect (req) {
     }
   }
   return
+}
+
+module.exports = {
+  currentRoot,
+  tempRedirects,
+  permanentRedirects,
+  redirect
 }

--- a/src/views/docs/en/about/upgrade-guide.md
+++ b/src/views/docs/en/about/upgrade-guide.md
@@ -27,7 +27,7 @@ Architect 9 (La Chupacabra) is primarily a maintenance release, dropping support
 
 ### Architect 8 (El Chupacabra)
 
-Architect 8 (El Chupacabra) improves API Gateway `HTTP` APIs by adding [`@proxy`](/docs/en/reference/arc-pragmas/@proxy) support for migrating old APIs, and `any` HTTP method support and `*` catchall syntax, while also improving the default greedy catchall behavior of `get /` to be literal to what's found in the Architect manifest.
+Architect 8 (El Chupacabra) improves API Gateway `HTTP` APIs by adding [`@proxy`](/docs/en/reference/project-manifest/proxy) support for migrating old APIs, and `any` HTTP method support and `*` catchall syntax, while also improving the default greedy catchall behavior of `get /` to be literal to what's found in the Architect manifest.
 
 Although uncommon, certain Architect applications that use `get /` beyond handling `get` requests to `/` may be impacted by this change. [See more below](#architect-7-&rarr;-8).
 
@@ -378,7 +378,7 @@ Architect 6 is a milestone release that solves some of the most crucial feedback
   - This includes Ruby and Python support for the `sandbox` local dev server
   - It also includes ports of the Architect Functions module for [Ruby](https://github.com/architect/arc-functions-ruby) and [Python](https://github.com/architect/arc-functions-python)
     - Note: Functions for Ruby and Python is not yet at feature parity with the Node.js version, largely dictated by the availability and consistency of certain lower-level APIs in those runtimes.
-    - As such, broadly speaking, if using Architect Functions in your [HTTP functions](/en/reference/functions/http-functions) we recommend the Node.js version, which includes the most extensive support for front-end facing use cases.
+    - As such, broadly speaking, if using Architect Functions in your [HTTP functions](/docs/en/reference/project-manifest/http) we recommend the Node.js version, which includes the most extensive support for front-end facing use cases.
 - **Architect 6 now provisions CDNs with the `@cdn` pragma**
   - Finally, provision fast, fully-featured, global CDNs to live in front of your web app
   - This enables your web application to take advantage of crucial features like edge caching and global points of presence
@@ -444,7 +444,7 @@ The following Architect 5 `request` parameters changed in Architect 6:
   - Still one of `GET`, `POST`, `PATCH`, `PUT`, or `DELETE`
 - `body` is no longer a pre-parsed object
   - `body` is now either `null` or a base64-encoded buffer
-  - `body` must first be decoded, then parsed, to make use of it; Architect provides a handy helper to take care of this for you, see: [parsing HTTP request bodies](/en/reference/functions/http-functions#requests)
+  - `body` must first be decoded, then parsed, to make use of it; Architect provides a handy helper to take care of this for you, see: [parsing HTTP request bodies](/docs/en/reference/runtime-helpers/node.js#arc.http)
 - `params` is now `pathParameters`
   - Still an object containing any URL params, if defined in your HTTP function's path (e.g. `foo` in `GET /:foo/bar`)
 - `query` is now `queryStringParameters`
@@ -540,8 +540,8 @@ Architect version 5 is here!
 
 Things we added:
 
-- [WebSocket support](/en/guides/tutorials/adding-websockets-to-your-app)
-- [New middleware](/en/reference/runtime-helper-reference/arc-http) - added later in arc 4, and out of the box in Arc 5
+- [WebSocket support](/docs/en/reference/project-manifest/ws)
+- [New middleware](/docs/en/reference/runtime-helpers/node.js#arc.http) - added later in arc 4, and out of the box in Arc 5
 
 ### 4.x
 
@@ -705,7 +705,7 @@ Yes! It is supported by and forwards compatible in Architect 7, including use wi
 
 ### Does `@architect/functions` work in Architect 6?
 
-Yes! It is supported by and forwards compatible in Architect 6. Additionally, it has been expanded to include [`@tables` support for working with data](/en/reference/databases/tables).
+Yes! It is supported by and forwards compatible in Architect 6. Additionally, it has been expanded to include [`@tables` support for working with data](/docs/en/reference/project-manifest/tables).
 
 ### Will `@architect/functions` continue working in Architect 5?
 

--- a/src/views/docs/en/reference/cli/env.md
+++ b/src/views/docs/en/reference/cli/env.md
@@ -16,7 +16,7 @@ arc env [testing|staging|production] {VARIABLE_NAME} {VARIABLE_VALUE}
 
 It is imperative that the `ARC_APP_SECRET` environment variable be set to
 something secret - especially in your production environment! This secret is
-used to encode HTTP sessions if you use the [`@architect/functions` runtime helpers](../runtime/node#arc.http.session).
+used to encode HTTP sessions if you use the [`@architect/functions` runtime helpers](../runtime-helpers/node.js#arc.http.session).
 
 ## Examples
 

--- a/src/views/docs/en/reference/configuration/local-preferences.md
+++ b/src/views/docs/en/reference/configuration/local-preferences.md
@@ -46,7 +46,7 @@ In the above example, new `@http` functions will use your `path/to/template/http
 
 Configure environment variables for `testing` with `arc sandbox` and deployed `staging` and `production` environments.
 
-Sync environment variables to your project by using the [`arc env` CLI command](/reference/cli/env). If the preferences file does not exist Architect will generate `preferences.arc` file.
+Sync environment variables to your project by using the [`arc env` CLI command](../cli/env). If the preferences file does not exist Architect will generate `preferences.arc` file.
 
 > Note: any time you run `arc env`, your unsynced local environment variables will be overwritten.
 
@@ -80,7 +80,7 @@ ANOTHER_VAR=only-for-testing
 
 ## `@sandbox`
 
-Define [`arc sandbox`](../cli/sandbox) preferences. If you are not using a [`.env` file](.env) then any environment variables set using the [`arc env` CLI](../cli/env) will be stored in the preferences file. In this scenario it is best _not_ to revision the preferences file in source control.
+Define [`arc sandbox`](../cli/sandbox) preferences. If you are not using a `.env` file then any environment variables set using the [`arc env` CLI](../cli/env) will be stored in the preferences file. In this scenario it is best _not_ to revision the preferences file in source control.
 
 ### `env` - String
 

--- a/test/backend/sandbox-http-test.js
+++ b/test/backend/sandbox-http-test.js
@@ -1,21 +1,47 @@
+let link = require('linkinator')
 let test = require('tape')
 let tiny = require('tiny-json-http')
 let sandbox = require('@architect/sandbox')
+let { currentRoot } = require('../../src/shared/redirect-map')
 
 const host = 'http://localhost:3333'
+const root = `${host}${currentRoot}`
 
-test('sandbox HTTP request', async t => {
-  t.plan(4)
-
+test('check key paths and find broken links', async (t) => {
   await sandbox.start({ quiet: true })
-  t.pass(`sandbox started on ${host}`)
+  t.pass(`sandbox started at ${host}`)
 
-  let quickstart = await tiny.get({ url: `${host}/docs/en/get-started/quickstart` })
+  let quickstart = await tiny.get({ url: root })
   t.ok(quickstart.body, 'got quickstart document')
 
   let playground = await tiny.get({ url: `${host}/playground` })
   t.ok(playground.body, 'got static playground document')
 
+  const checker = new link.LinkChecker()
+
+  checker.on('link', result => {
+    if (result.state === 'BROKEN')
+      console.log(`${result.status} ${result.url} from ${result.parent}`)
+  })
+
+  const result = await checker.check({
+    concurrency: 10, // default of 100 causes functions to exceed 5s timeout
+    path: root,
+    recurse: true,
+    linksToSkip: [
+      'https://www.godaddy.com', // GoDaddy 403s crawlers
+      'https://github.com/architect/arc.codes/edit/' // skip all the "Edit on GitHub" links
+    ],
+  })
+
+  const brokenCount = result.links.filter(x => x.state === 'BROKEN').length
+  const okCount = result.links.filter(x => x.state === 'OK').length
+
+  t.ok(brokenCount === 0, `${brokenCount} broken link${brokenCount > 1 || brokenCount === 0 ? 's' : ''}`)
+  t.pass(`${okCount} working link${okCount > 1 || okCount === 0 ? 's' : ''}`)
+
   await sandbox.end()
   t.pass('sandbox ended')
+
+  t.end()
 })

--- a/test/backend/sandbox-http-test.js
+++ b/test/backend/sandbox-http-test.js
@@ -1,4 +1,3 @@
-let link = require('linkinator')
 let test = require('tape')
 let tiny = require('tiny-json-http')
 let sandbox = require('@architect/sandbox')
@@ -7,7 +6,7 @@ let { currentRoot } = require('../../src/shared/redirect-map')
 const host = 'http://localhost:3333'
 const root = `${host}${currentRoot}`
 
-test('check key paths and find broken links', async (t) => {
+test('check key paths', async (t) => {
   await sandbox.start({ quiet: true })
   t.pass(`sandbox started at ${host}`)
 
@@ -16,29 +15,6 @@ test('check key paths and find broken links', async (t) => {
 
   let playground = await tiny.get({ url: `${host}/playground` })
   t.ok(playground.body, 'got static playground document')
-
-  const checker = new link.LinkChecker()
-
-  checker.on('link', result => {
-    if (result.state === 'BROKEN')
-      console.log(`${result.status} ${result.url} from ${result.parent}`)
-  })
-
-  const result = await checker.check({
-    concurrency: 10, // default of 100 causes functions to exceed 5s timeout
-    path: root,
-    recurse: true,
-    linksToSkip: [
-      'https://www.godaddy.com', // GoDaddy 403s crawlers
-      'https://github.com/architect/arc.codes/edit/' // skip all the "Edit on GitHub" links
-    ],
-  })
-
-  const brokenCount = result.links.filter(x => x.state === 'BROKEN').length
-  const okCount = result.links.filter(x => x.state === 'OK').length
-
-  t.ok(brokenCount === 0, `${brokenCount} broken link${brokenCount > 1 || brokenCount === 0 ? 's' : ''}`)
-  t.pass(`${okCount} working link${okCount > 1 || okCount === 0 ? 's' : ''}`)
 
   await sandbox.end()
   t.pass('sandbox ended')


### PR DESCRIPTION
I used linkinator locally to test for bad links, but thought it might make for a good test programatically.

~~Still working on it.~~

This works best as a GitHub CI Action. (originally a part of the test suite)

<img width="527" alt="image" src="https://user-images.githubusercontent.com/15697/140434828-6490ec47-60ba-4639-b876-79eafd5d68fa.png">

### Notes

- It's a bit slow. Takes the HTTP test from <1s to ~ 8s (fine in GH Actions)
- it doesn't report 301/2 redirects -- so it can't test if docs use outdated links, just busted ones.
- it adds 98kB (maybe less because shared dependencies)
- it helped find ~8 broken links and will help a ton when updating doc file structure