### PR TITLE
Right rail page table of contents

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "highlight.js": "^11.3.1",
     "js-yaml": "^4.1.0",
     "markdown-it": "^12.2.0",
-    "markdown-it-anchor": "^8.4.1",
     "markdown-it-external-anchor": "^1.0.0",
     "markdown-it-front-matter": "^0.2.3",
+    "markdown-it-toc-and-anchor": "^4.2.0",
     "onigasm": "^2.2.5",
     "slugify": "^1.6.1"
   },

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -105,3 +105,32 @@ details summary .plus-icon, details[open] summary .minus-icon {
 details[open] summary .plus-icon, details summary .minus-icon {
   display: none;
 }
+
+main {
+  display: flex;
+}
+
+.right-sidebar {
+  display: block;
+  font-size: .9rem;
+  min-width:16rem;
+}
+
+@media only screen and (max-width:80rem) {
+  main {
+    display: block;
+  }
+
+  .right-sidebar {
+    display: none;
+  }
+}
+
+.right-sidebar a {
+  text-decoration: none;
+}
+
+.right-sidebar a.active, .right-sidebar a.active code {
+  font-weight: 700;
+  color: var(--g10);
+}

--- a/public/index.js
+++ b/public/index.js
@@ -88,4 +88,25 @@
     let currentHeight = (el[scrollHeight] || body[scrollHeight]) - body.clientHeight
     return Math.floor((currentTop / currentHeight) * 100)
   }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    const observer = new IntersectionObserver(entries => {
+      const allSectionLinks = document.querySelectorAll('.right-sidebar li a')
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          const id = entry.target.getAttribute('id')
+          allSectionLinks.forEach(link => link.classList.remove('active'))
+          document.querySelector(`.right-sidebar a[href="#${id}"]`).classList.add('active')
+        }
+      })
+    }, {
+      root: null,
+      rootMargin: `0% 0% -80% 0%`,
+      threshold: [ 1 ],
+    })
+
+    document.querySelectorAll('h2, h3, h4, h5, h6').forEach((header) => {
+      observer.observe(header)
+    })
+  })
 }())

--- a/public/static.json
+++ b/public/static.json
@@ -1,12 +1,12 @@
 {
   "arc.codes.png": "arc.codes-dffa3a9996.png",
-  "index.js": "index-0fe9efa0e6.js",
+  "index.js": "index-5d5fd54a2b.js",
   "playground.html": "playground-2fe1115dbf.html",
   "playground.js": "playground-67bb53bc87.js",
   "components/arc-tab.js": "components/arc-tab-efbcb40f74.js",
   "components/arc-viewer.js": "components/arc-viewer-3de6ce2a83.js",
   "css/docsearch.css": "css/docsearch-27dbba82ed.css",
-  "css/index.css": "css/index-a80104bde7.css",
+  "css/index.css": "css/index-547bdacc3e.css",
   "css/styles.css": "css/styles-cf4510a1b6.css",
   "css/syntax.css": "css/syntax-0339098006.css"
 }

--- a/src/views/modules/document/html.js
+++ b/src/views/modules/document/html.js
@@ -12,11 +12,13 @@ export default function HTML (props = {}) {
     children = [],
     editURL = '',
     lang = 'en',
+    pageToC = '',
     scripts = '',
     state = {},
     thirdparty = '',
     title = ''
   } = props
+
   let scriptTags = scripts &&
     Array.isArray(props.scripts)
     ? scripts.map(src => Script({ src })).join('')
@@ -71,6 +73,12 @@ ${Symbols}
         <div class="pb4 docs">
           ${children}
           ${EditLink({ editURL })}
+        </div>
+      </div>
+      <div class="pl0 w-toc sticky top0 right-sidebar">
+        <h4>Table of Contents</h4>
+        <div class="pt0 ml-none-lg">
+          ${pageToC.replace(/class="mb1"/g, 'class="list-none"')}
         </div>
       </div>
     </main>


### PR DESCRIPTION
This PR adds a right rail into the docs which contains a table of contents for the page. 

Right now the toc includes all the h2, h3, h4, h5 and h6 headers on the page. I can leave it like this or reduce the toc to just the h2 and h3 tags. I know some sites limit how deep the toc goes.

It removes the package `markdown-it-anchor` and replaces it with `markdown-it-toc-and-anchor` which serves the dual purpose of adding anchors creating the toc. I created a `slugify` method so that the slugs would not change between `markdown-it-anchor` and `markdown-it-toc-and-anchor`. I actually prefer the `markdown-it-toc-and-anchor` slugs but it would necessitate changing all our current in page links and possibly break bookmarks so I went with a custom `slugify`.

I am more than happy to make UI tweaks, I just wanted to get this out so folks could see how the functionality would work. The right rail disappears as the screen size goes below 80rem (1280px).

![right-toc](https://user-images.githubusercontent.com/353180/141485248-85a5c48d-05d9-4029-b8fb-d9f0476d443e.gif)

Closes Right-hand subnav #458

Signed-off-by: Simon MacDonald <simon.macdonald@gmail.com>