### PR TITLE
clarify asap docs

### DIFF
--- a/src/views/docs/en/reference/runtime-helpers/node.js.md
+++ b/src/views/docs/en/reference/runtime-helpers/node.js.md
@@ -628,9 +628,9 @@ exports.handler = asap(params)
 ```javascript
 // asap as arc.http.async middleware
 let arc = require('@architect/functions')
-let asap = require('@architect/asap')()
+let asap = require('@architect/asap')
 
-exports.handler = arc.http.async(render, asap)
+exports.handler = arc.http.async(render, asap())
 
 async function render (req) {
   // If user is logged in, show them a custom logged in page


### PR DESCRIPTION
This is a small change to clarify using the asap function in the async middleware pattern. 

In the docs it includes these two examples but the asap is different in each. Calling asap returns a handler so in the first example asap is that factory function and in the second example it is the handler that is returned (not sure if that terminology is exactly correct). Either way it is confusing. There may be a different way to clear it up that would be better. 

This is how it is currently shown in the docs. 
------
```javascript
// basic usage
let asap = require('@architect/asap')
let params = { cacheControl: 'max-age=0' }
exports.handler = asap(params)
```

```javascript
// asap as arc.http.async middleware
let arc = require('@architect/functions')
let asap = require('@architect/asap')()

exports.handler = arc.http.async(render, asap)

async function render (req) {
  // If user is logged in, show them a custom logged in page
  if (req.path === '/' && req.session.account) {
    return { html: `<body>Hello ${req.session.account.name}!</body>` }
  }
  // Otherwise, load the logged out static page
  return
}
```