### PR TITLE
Correct quickstart instructions

### DIFF
--- a/src/views/docs/en/get-started/detailed-aws-setup.md
+++ b/src/views/docs/en/get-started/detailed-aws-setup.md
@@ -128,13 +128,13 @@ The following command uses `npm`, the package manager for Node.js.
 To create an entirely new Architect project:
 
 ```bash
-npm init @architect ./testapp
+npm exec @architect/create ./testapp
 ```
 
 To install Architect locally into an existing project:
 
 ```bash
-npm init @architect ./testapp
+npm exec @architect/create ./testapp
 ```
 
 Or you can install Architect globally, enabling you to use Architect from any directory on your computer. When doing so, you should also be sure to install the AWS SDK globally as well.

--- a/src/views/docs/en/get-started/detailed-aws-setup.md
+++ b/src/views/docs/en/get-started/detailed-aws-setup.md
@@ -127,15 +127,51 @@ The following command uses `npm`, the package manager for Node.js.
 
 To create an entirely new Architect project:
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create ./testapp
+npm init @architect ./testapp
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" ./testapp
+```
+</div>
+</arc-tab>
 
 To install Architect locally into an existing project:
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create ./testapp
+npm init @architect ./testapp
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" ./testapp
+```
+</div>
+</arc-tab>
 
 Or you can install Architect globally, enabling you to use Architect from any directory on your computer. When doing so, you should also be sure to install the AWS SDK globally as well.
 

--- a/src/views/docs/en/get-started/detailed-aws-setup.md
+++ b/src/views/docs/en/get-started/detailed-aws-setup.md
@@ -148,6 +148,8 @@ npm init "@architect" ./testapp
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 To install Architect locally into an existing project:
 
@@ -172,6 +174,8 @@ npm init "@architect" ./testapp
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 Or you can install Architect globally, enabling you to use Architect from any directory on your computer. When doing so, you should also be sure to install the AWS SDK globally as well.
 

--- a/src/views/docs/en/get-started/quickstart.md
+++ b/src/views/docs/en/get-started/quickstart.md
@@ -8,9 +8,27 @@ description: Get started quickly with Architect
 
 Assuming Node.js 14+ is installed, open your terminal and create a new Architect project:
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create your-app
+npm init @architect your-app
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" your-app
+```
+</div>
+</arc-tab>
 
 Start the local dev server:
 

--- a/src/views/docs/en/get-started/quickstart.md
+++ b/src/views/docs/en/get-started/quickstart.md
@@ -29,6 +29,8 @@ npm init "@architect" your-app
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 Start the local dev server:
 

--- a/src/views/docs/en/get-started/quickstart.md
+++ b/src/views/docs/en/get-started/quickstart.md
@@ -9,13 +9,13 @@ description: Get started quickly with Architect
 Assuming Node.js 14+ is installed, open your terminal and create a new Architect project:
 
 ```bash
-npm init @architect new-app
+npm exec @architect/create your-app
 ```
 
 Start the local dev server:
 
 ```bash
-cd new-app
+cd your-app
 npx arc sandbox
 ```
 > `Cmd / Ctrl + c` exits the sandbox

--- a/src/views/docs/en/guides/backend/events-and-queues.md
+++ b/src/views/docs/en/guides/backend/events-and-queues.md
@@ -34,10 +34,30 @@ In this tutorial, we will create an event topic, POST JSON data to invoke a subs
 
 1. We will start with a fresh project and install dependencies.
 
-``` bash
-npm exec @architect/create ./arc-event-app
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
+```bash
+npm init @architect arc-event-app
 cd arc-event-app
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" arc-event-app
+cd arc-event-app
+```
+</div>
+</arc-tab>
+
 2. Open up your `app.arc` file and add the `@event` pragma along with a POST route
 
 ```arc
@@ -137,10 +157,29 @@ Another common background task is `@scheduled` functions. These functions are in
 
 The first thing we will need is a fresh Architect project. We can create one directly from the terminal.
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create ./arc-scheduled-app
+npm init @architect ./arc-scheduled-app
 cd arc-scheduled-app
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" ./arc-scheduled-app
+cd arc-scheduled-app
+```
+</div>
+</arc-tab>
 
 Now we can open up the `app.arc` file and add a scheduled function to the manifest.
 
@@ -231,10 +270,29 @@ The `Events` property on the `Daily` function shows that this is a scheduled eve
 
 Let's make an example message queue by starting with a fresh Architect project.
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create ./arc-queues-app
+npm init @architect ./arc-queues-app
 cd arc-queues-app
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" ./arc-queues-app
+cd arc-queues-app
+```
+</div>
+</arc-tab>
 
 Open up the `app.arc` file and modify the manifest to include our `@queues` function as follows:
 

--- a/src/views/docs/en/guides/backend/events-and-queues.md
+++ b/src/views/docs/en/guides/backend/events-and-queues.md
@@ -57,6 +57,8 @@ cd arc-event-app
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 2. Open up your `app.arc` file and add the `@event` pragma along with a POST route
 
@@ -180,6 +182,8 @@ cd arc-scheduled-app
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 Now we can open up the `app.arc` file and add a scheduled function to the manifest.
 
@@ -293,6 +297,8 @@ cd arc-queues-app
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 Open up the `app.arc` file and modify the manifest to include our `@queues` function as follows:
 

--- a/src/views/docs/en/guides/backend/events-and-queues.md
+++ b/src/views/docs/en/guides/backend/events-and-queues.md
@@ -35,7 +35,7 @@ In this tutorial, we will create an event topic, POST JSON data to invoke a subs
 1. We will start with a fresh project and install dependencies.
 
 ``` bash
-npm init @architect ./arc-event-app
+npm exec @architect/create ./arc-event-app
 cd arc-event-app
 ```
 2. Open up your `app.arc` file and add the `@event` pragma along with a POST route
@@ -138,7 +138,7 @@ Another common background task is `@scheduled` functions. These functions are in
 The first thing we will need is a fresh Architect project. We can create one directly from the terminal.
 
 ```bash
-npm init @architect ./arc-scheduled-app
+npm exec @architect/create ./arc-scheduled-app
 cd arc-scheduled-app
 ```
 
@@ -232,7 +232,7 @@ The `Events` property on the `Daily` function shows that this is a scheduled eve
 Let's make an example message queue by starting with a fresh Architect project.
 
 ```bash
-npm init @architect ./arc-queues-app
+npm exec @architect/create ./arc-queues-app
 cd arc-queues-app
 ```
 

--- a/src/views/docs/en/guides/frontend/middleware.md
+++ b/src/views/docs/en/guides/frontend/middleware.md
@@ -263,9 +263,27 @@ Architect also has a middleware function to wrap Express.js logic, this is good 
 
 This command will create a new directory, install a local version of Architect, and generate a folder structure.
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create ./myexpress
+npm init @architect ./myexpress
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" ./myexpress
+```
+</div>
+</arc-tab>
 
 2. Take a look inside and you will see one HTTP function, `get-index`. This will be a single Lambda that will be our entire Express app behind an API Gateway endpoint.
 

--- a/src/views/docs/en/guides/frontend/middleware.md
+++ b/src/views/docs/en/guides/frontend/middleware.md
@@ -284,6 +284,8 @@ npm init "@architect" ./myexpress
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 2. Take a look inside and you will see one HTTP function, `get-index`. This will be a single Lambda that will be our entire Express app behind an API Gateway endpoint.
 

--- a/src/views/docs/en/guides/frontend/middleware.md
+++ b/src/views/docs/en/guides/frontend/middleware.md
@@ -264,7 +264,7 @@ Architect also has a middleware function to wrap Express.js logic, this is good 
 This command will create a new directory, install a local version of Architect, and generate a folder structure.
 
 ```bash
-npm init @architect ./myexpress
+npm exec @architect/create ./myexpress
 ```
 
 2. Take a look inside and you will see one HTTP function, `get-index`. This will be a single Lambda that will be our entire Express app behind an API Gateway endpoint.

--- a/src/views/docs/en/guides/frontend/single-page-apps.md
+++ b/src/views/docs/en/guides/frontend/single-page-apps.md
@@ -202,12 +202,33 @@ In this guide, we'll be using the frontend library [React](https://reactjs.org/)
 
 Initialize an Architect project, change directories into the project folder, create a `package.json` file, and install NPM packages:
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create --static ./my-spa
+npm init @architect --static ./my-spa
 cd my-spa
 npm init -f
 npm install react react-dom parcel-bundler @architect/sandbox
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" --static ./my-spa
+cd my-spa
+npm init -f
+npm install react react-dom parcel-bundler @architect/sandbox
+```
+</div>
+</arc-tab>
 
 2. Update the build folder configuration in `app.arc`
 

--- a/src/views/docs/en/guides/frontend/single-page-apps.md
+++ b/src/views/docs/en/guides/frontend/single-page-apps.md
@@ -203,7 +203,7 @@ In this guide, we'll be using the frontend library [React](https://reactjs.org/)
 Initialize an Architect project, change directories into the project folder, create a `package.json` file, and install NPM packages:
 
 ```bash
-npm init @architect --static ./my-spa
+npm exec @architect/create --static ./my-spa
 cd my-spa
 npm init -f
 npm install react react-dom parcel-bundler @architect/sandbox

--- a/src/views/docs/en/guides/frontend/single-page-apps.md
+++ b/src/views/docs/en/guides/frontend/single-page-apps.md
@@ -229,6 +229,8 @@ npm install react react-dom parcel-bundler @architect/sandbox
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>
 
 2. Update the build folder configuration in `app.arc`
 

--- a/src/views/docs/en/reference/cli/init.md
+++ b/src/views/docs/en/reference/cli/init.md
@@ -51,3 +51,5 @@ npm init "@architect" myapp
 ```
 </div>
 </arc-tab>
+</div>
+</arc-viewer>

--- a/src/views/docs/en/reference/cli/init.md
+++ b/src/views/docs/en/reference/cli/init.md
@@ -31,5 +31,5 @@ arc init
 ### Create a Node app with Architect installed locally
 
 ```bash
-npm init @architect myapp
+npm exec @architect/create myapp
 ```

--- a/src/views/docs/en/reference/cli/init.md
+++ b/src/views/docs/en/reference/cli/init.md
@@ -30,6 +30,24 @@ arc init
 
 ### Create a Node app with Architect installed locally
 
+<arc-viewer default-tab=bash>
+<div slot=contents>
+<arc-tab label=bash>
+<h5>Bash/cmd.exe</h5>
+<div slot=content>
+
 ```bash
-npm exec @architect/create myapp
+npm init @architect myapp
 ```
+</div>
+</arc-tab>
+
+<arc-tab label=PowerShell>
+<h5>PowerShell</h5>
+<div slot=content>
+
+```powershell
+npm init "@architect" myapp
+```
+</div>
+</arc-tab>


### PR DESCRIPTION
The docs say `npm init @architect new-app` but that does not work, because [`npm init`](https://docs.npmjs.com/cli/v8/commands/npm-init) will try to run `@architect/create-new-app`.
`npm init @architect` will call `@architect/create`, but once you add something after it, it looks for `create-<thing>`.

I had to use `npm exec @architect/create new-app` to get it to create a folder called `new-app`. Updating the docs with the correct instruction. Also using `your-app` so it's clear that `new-app` is not some kind of keyword.
