### PR TITLE
Node.js Runtime Helpers (aka architect/functions) doc update

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@architect/asap": "^4.1.0",
-    "@architect/functions": "^4.0.0",
+    "@architect/functions": "^4.1.1",
     "@architect/inventory": "^2.1.1",
     "@architect/package": "^7.1.1",
     "@architect/syntaxes": "github:architect/syntaxes#v1.2.1",
@@ -34,7 +34,7 @@
     "eslint": "^8.1.0",
     "linkinator": "^2.14.5",
     "spellchecker-cli": "^4.8.0",
-    "tap-arc": "^0.1.0",
+    "tap-arc": "^0.1.1",
     "tape": "^5.3.1",
     "tiny-json-http": "^7.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "dependencies": {
     "@architect/asap": "^4.1.0",
     "@architect/functions": "^4.1.1",
-    "@architect/inventory": "^2.1.1",
-    "@architect/package": "^7.1.1",
+    "@architect/inventory": "^2.2.1",
+    "@architect/package": "^7.2.0",
     "@architect/syntaxes": "github:architect/syntaxes#v1.2.1",
     "@toycode/markdown-it-class": "^1.2.4",
     "esm": "^3.2.25",
@@ -25,17 +25,17 @@
     "markdown-it-external-anchor": "^1.0.0",
     "markdown-it-front-matter": "^0.2.3",
     "markdown-it-toc-and-anchor": "^4.2.0",
-    "slugify": "^1.6.1"
+    "slugify": "^1.6.3"
   },
   "devDependencies": {
-    "@architect/architect": "^9.2.0",
+    "@architect/architect": "^9.4.2",
     "@architect/eslint-config": "^2.0.1",
     "@architect/spellcheck-dictionary": "github:architect/spellcheck-dictionary",
-    "eslint": "^8.1.0",
-    "linkinator": "^2.14.5",
-    "spellchecker-cli": "^4.8.0",
+    "eslint": "^8.4.1",
+    "linkinator": "^2.16.2",
+    "spellchecker-cli": "^4.8.1",
     "tap-arc": "^0.1.1",
-    "tape": "^5.3.1",
+    "tape": "^5.3.2",
     "tiny-json-http": "^7.3.1"
   },
   "eslintConfig": {

--- a/public/index.js
+++ b/public/index.js
@@ -95,8 +95,9 @@
       entries.forEach(entry => {
         if (entry.isIntersecting) {
           const id = entry.target.getAttribute('id')
+          const sectionLink = document.querySelector(`.right-sidebar a[href="#${id}"]`)
           allSectionLinks.forEach(link => link.classList.remove('active'))
-          document.querySelector(`.right-sidebar a[href="#${id}"]`).classList.add('active')
+          if (sectionLink) sectionLink.classList.add('active')
         }
       })
     }, {

--- a/public/index.js
+++ b/public/index.js
@@ -72,6 +72,7 @@
     codeBlock.appendChild(button)
   }
 
+  // Document percent read progress bar
   let bar = document.querySelector('.indicator')
   bar.style.width = getScrollPercent(main)
   main.onscroll = setReadPercent.bind(null, main)
@@ -89,6 +90,17 @@
     return Math.floor((currentTop / currentHeight) * 100)
   }
 
+  /* Right sidebar behavior */
+  // ↑ Top link fancy scroll enhancement
+  document.getElementById('top-link').onclick = function (e) {
+    e.preventDefault()
+    main
+      .querySelectorAll('div > h1')[0]
+      .scrollIntoView({ behavior: 'smooth' })
+    history.replaceState(null, null, ' ')
+  }
+
+  // highlight doc outline item per scroll position
   window.addEventListener('DOMContentLoaded', () => {
     const observer = new IntersectionObserver(entries => {
       const allSectionLinks = document.querySelectorAll('.right-sidebar li a')

--- a/public/static.json
+++ b/public/static.json
@@ -1,6 +1,6 @@
 {
   "arc.codes.png": "arc.codes-dffa3a9996.png",
-  "index.js": "index-baecb620e3.js",
+  "index.js": "index-e3a8440e18.js",
   "playground.html": "playground-2fe1115dbf.html",
   "playground.js": "playground-67bb53bc87.js",
   "components/arc-tab.js": "components/arc-tab-efbcb40f74.js",

--- a/public/static.json
+++ b/public/static.json
@@ -1,6 +1,6 @@
 {
   "arc.codes.png": "arc.codes-dffa3a9996.png",
-  "index.js": "index-5d5fd54a2b.js",
+  "index.js": "index-baecb620e3.js",
   "playground.html": "playground-2fe1115dbf.html",
   "playground.js": "playground-67bb53bc87.js",
   "components/arc-tab.js": "components/arc-tab-efbcb40f74.js",

--- a/scripts/dictionary.txt
+++ b/scripts/dictionary.txt
@@ -1,14 +1,15 @@
 ℹ
 &rarr
 ACM
+ApiGatewayManagementApi
 arc-example-cors
 Cloudflare
 Dreamhost
 FQDN
+getConnection
 GoDaddy
 Graviton2
 konsumer
 LEANX
 Namecheap
-NameCheap
 ParcelJS

--- a/src/http/get-docs-000lang-catchall/index.js
+++ b/src/http/get-docs-000lang-catchall/index.js
@@ -23,7 +23,7 @@ const NotFound = require('@architect/views/modules/components/not-found.js').def
 const algolia = require('@architect/views/modules/components/algolia.js').default
 
 
-// reproduces the slugify algorithm used in markdown-it-anchor
+// reproduces the slugify algorithm used in markdown-it-external-anchor
 const slugify = (s) => encodeURIComponent(String(s).trim().toLowerCase().replace(/\s+/g, '-'))
 
 const cache = {} // cheap warm cache
@@ -87,7 +87,7 @@ async function handler (req) {
   }
 
   let frontmatter = {}
-  let pageToC = ''
+  let docOutline = ''
   const markdown = new Markdown({
     linkify: true,
     html: true,
@@ -103,7 +103,7 @@ async function handler (req) {
       tocFirstLevel: 2,
       tocLastLevel: 6,
       tocCallback: function (tocMarkdown, tocArray, tocHtml) {
-        pageToC = tocHtml
+        docOutline = tocHtml
       }
     })
     .use(frontmatterParser, function (str) {
@@ -125,13 +125,14 @@ async function handler (req) {
       description,
       editURL,
       lang,
-      pageToC,
+      docOutline,
       sections,
       scripts: [
         '/index.js',
         '/components/arc-viewer.js',
         '/components/arc-tab.js'
       ],
+      titleSlug: slugify(title),
       thirdparty: algolia(lang),
       title,
       toc

--- a/src/views/docs/en/get-started/quickstart.md
+++ b/src/views/docs/en/get-started/quickstart.md
@@ -6,6 +6,8 @@ description: Get started quickly with Architect
 
 > Architect is a simple tool to build and deliver powerful cloud function-based web apps and APIs
 
+## Create a new project
+
 Assuming Node.js 14+ is installed, open your terminal and create a new Architect project:
 
 <arc-viewer default-tab=bash>

--- a/src/views/docs/en/guides/developer-experience/custom-source-paths.md
+++ b/src/views/docs/en/guides/developer-experience/custom-source-paths.md
@@ -5,7 +5,7 @@ category: Developer experience
 
 Define resources in a more verbose format to configure custom Lambda source directories. Custom source paths are completely opt-in on a Lambda by Lambda basis; this is trading off default conventions for flexibility at the price of slightly more `app.arc` verbosity.
 
-### Use cases
+## Use cases
 
 - Migrate existing repos to serverless tech
 - Use frontend frameworks that have their own folder requirements

--- a/src/views/docs/en/reference/configuration/local-preferences.md
+++ b/src/views/docs/en/reference/configuration/local-preferences.md
@@ -73,7 +73,7 @@ Architect sandbox supports loading environment variables from a `.env` file. The
 
 ### Example `.env` file
 
-```shell
+```bash
 A_TESTING_ENV_VAR=something-for-testing
 ANOTHER_VAR=only-for-testing
 ```

--- a/src/views/docs/en/reference/runtime-helpers/deno.md
+++ b/src/views/docs/en/reference/runtime-helpers/deno.md
@@ -1,6 +1,6 @@
 ---
-title: Deno
-category: Runtime
+title: Deno runtime helpers
+category: Runtime helpers
 description: Deno runtime support
 ---
 

--- a/src/views/docs/en/reference/runtime-helpers/node.js.md
+++ b/src/views/docs/en/reference/runtime-helpers/node.js.md
@@ -6,18 +6,16 @@ description: Node.js runtime support
 
 Architect runtime helpers are optional, and designed to make it significantly easier to work with AWS CloudFormation provisioned resources and related assets.
 
-CloudFormation resources are generated with names more friendly for machines than people. Other frameworks leave resource discovery up to end users, which leads to ad hoc implementations becoming a frequent bug vector. Architect treats runtime discovery as a first class concern.
-
-> Amazon Resource Names (ARNs) are available at runtime to all Lambda functions defined in the same Architect project manifest. Things such as DynamoDB tables, SNS topics, SQS queues, API Gateway endpoints, and S3 static bucket ARNs are baked into `@architect/functions` so your runtime program logic interacts with resources using readable, people-friendly names defined in your Architect project manifest.
-
 Architect has two primary runtime helpers for Node.js:
 
-- [`@architect/functions`](#%40architect%2Ffunctions) - General purpose runtime helpers for various Architect resources, such as `@http`, `@tables`, etc.
+- [`@architect/functions`](#%40architect%2Ffunctions) - General purpose runtime helpers for various Architect resources, such as `@events`, `@http`, `@tables`, etc.
 - [`@architect/asap`](#%40architect%2Fasap) - Helper designed solely for delivering static assets via `@http` endpoints
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
 ## `@architect/functions`
+
+[View package source on GitHub](https://github.com/architect/functions/)
 
 ### Setup
 
@@ -33,30 +31,26 @@ Ensure `arc` is available to your Lambda function code:
 let arc = require('@architect/functions')
 ```
 
-
-### API
+### Interfaces
 
 - [`arc.events`](#arc.events) Publish / subscribe helpers for `@events` functions
 - [`arc.http`](#arc.http) Middleware and request/response normalization for `@http` functions using callbacks
-- [`arc.http.async`](#arc.http.async) Middleware and request/response normalization for `@http` functions using `async/await`
-- [`arc.http.express`](#arc.http.express) Express support for `@http` functions
-- [`arc.http.session`](#arc.http.session) Sessions for `@http` functions
+  <!-- - [`arc.http.async`](#arc.http.async) Middleware and request/response normalization for `@http` functions using `async/await`
+  - [`arc.http.express`](#arc.http.express) Express support for `@http` functions
+  - [`arc.http.session`](#arc.http.session) Sessions for `@http` functions -->
 - [`arc.queues`](#arc.queues) Publish/subscribe helpers for `@queues` functions
 - [`arc.services`](#arc.services) Retrieves the Architect service map, exposing metadata for all services making up the application
 - [`arc.static`](#arc.static) Get a `@static` asset path
 - [`arc.tables`](#arc.tables) Generates a DynamoDB client for `@tables`
 - [`arc.ws`](#arc.ws) WebSocket helpers for `@ws` functions
 
-
 ### `arc.events`
 
 Publish & subscribe helpers for `@events` functions.
 
-
 #### `arc.events.subscribe`
 
 Subscribe to events with a handler function. The function will be passed an `event` object, and, if not an `async` function, a callback to be called upon completion.
-
 
 ##### Examples
 
@@ -84,13 +78,11 @@ function handler (event, callback) {
 }
 ```
 
-
 #### `arc.events.publish`
 
 Publish an event to an `@events` function. An object containing two properties is required:
 - **`name`** (string) - name of the `@events` function you'd like to publish to
 - **`payload`** (object or array) - payload to be published
-
 
 ##### Examples
 
@@ -103,6 +95,7 @@ await arc.events.publish({
   payload: { hits: 1 },
 })
 ```
+
 ```javascript
 // continuation passing
 let arc = require('@architect/functions')
@@ -113,12 +106,11 @@ arc.events.publish({
 }, (err) => console.log)
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
 ### `arc.http`
 
 `arc.http` provides middleware and request/response normalization for `@http` functions using Express-style callbacks.
-
 
 #### Requests
 
@@ -129,7 +121,6 @@ arc.events.publish({
 - Added properties commonplace in other web servers, such as `req.params` (as opposed to the much more verbose `req.queryStringParameters`)
 
 Handler functions passed to `arc.http[.async]` receive a `request` object containing all of the [API Gateway request properties](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) specific to `HTTP` and `REST` APIs. Additionally, the following properties are added or improved for convenience:
-
 
 - `body` - **object**
   - Automatically parsed if present; `{}` if request has no body
@@ -156,7 +147,6 @@ Handler functions passed to `arc.http[.async]` receive a `request` object contai
 > Caveat: Architect Functions does not deal in compatibility with `req.requestContext`; request context semantics are specific to the version of API Gateway in use (`REST` or `HTTP`)
 
 > Learn more about [API Gateway request payloads here](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)
-
 
 #### Responses
 
@@ -194,8 +184,7 @@ Finally, you may also return a raw JavaScript Error, which will be interpreted a
 
 > Learn more about [API Gateway response payloads here](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html)
 
-
-#### API
+#### `arc.http()`
 
 Define `arc.http` middleware by passing one or more functions as parameters. A function can exit the middleware queue early by calling back with a [valid HTTP response payload](#responses).
 
@@ -206,7 +195,6 @@ Define `arc.http` middleware by passing one or more functions as parameters. A f
   - Callback that accepts either a [response object](#response) or Error
 - `next` - **function** (if not the final middleware)
   - Callback to invoke the next `arc.http` middleware function
-
 
 ##### Examples
 
@@ -244,12 +232,10 @@ function handler(req, res) {
   })
 }
 ```
----
 
-#### `arc.http.async`
+<hr class="mt3 border-solid border0 border-b1" />
 
-
-#### API
+#### `arc.http.async()`
 
 Define `arc.http.async` middleware by passing one or more `async` functions as parameters. A function can exit the middleware queue early by returning a [valid HTTP response payload](#responses)).
 
@@ -260,7 +246,6 @@ Define `arc.http.async` middleware by passing one or more `async` functions as p
   - Standard API Gateway context object
 
 Each middleware function can invoke the following function by returning the `request` object, or by reaching the end of execution.
-
 
 ##### Examples
 
@@ -296,12 +281,11 @@ async function handler(req) {
 }
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
-#### `arc.http.express`
+#### `arc.http.express()`
 
 [Express](https://expressjs.com) migration helper.
-
 
 ##### Examples
 
@@ -316,7 +300,7 @@ app.get('/cool', (req, res)=> res.send('very cool'))
 exports.handler = arc.http.express(app)
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
 #### `arc.http.session`
 
@@ -324,7 +308,7 @@ exports.handler = arc.http.express(app)
 
 These operations are automatically handled for you when using `arc.http[.async]`; only use `arc.http.session` if you prefer handling session reads and writes yourself.
 
-#### API
+##### Methods
 
 - `read(request[, callback]) → [Promise]`
   - Accepts a [request object](#requests)
@@ -335,7 +319,6 @@ These operations are automatically handled for you when using `arc.http[.async]`
   - Must be `await`ed if no callback is provided
 
 > Please note that session variable encoding and decoding relies on the `ARC_APP_SECRET` [environment variable](../cli/env) being set to something secret and not easily guessable. If you use Architect sessions, please be sure to [set the `ARC_APP_SECRET` environment variable](../cli/env)!
-
 
 ##### Examples
 
@@ -357,17 +340,15 @@ exports.handler = async function handler (req) {
 }
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
 ### `arc.queues`
 
 Publish & subscribe helpers for `@queues` functions.
 
-
 #### `arc.queues.subscribe`
 
 Subscribe to queues with a handler function. The function will be passed an `event` object, and, if not an `async` function, a callback to be called upon completion.
-
 
 ##### Examples
 
@@ -395,13 +376,11 @@ function handler (event, callback) {
 }
 ```
 
-
 #### `arc.queues.publish`
 
 Publish an event to an `@queues` function. An object containing two properties is required:
 - **`name`** (string) - name of the `@queues` function you'd like to publish to
 - **`payload`** (object or array) - payload to be published
-
 
 ##### Examples
 
@@ -414,6 +393,7 @@ await arc.queues.publish({
   payload: { hits: 1 },
 })
 ```
+
 ```javascript
 // continuation passing
 let arc = require('@architect/functions')
@@ -424,22 +404,29 @@ arc.queues.publish({
 }, (err) => console.log)
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
-### `arc.services`
+### `arc.services()`
 
-Retrieves the Architect service map: an object mapping the plugins and out-of-the-box Architect infrastructure that makes up the application.
+CloudFormation resources are generated with names more friendly for machines than people. Other frameworks leave resource discovery up to end users, which leads to ad hoc implementations becoming a frequent bug vector. Architect treats runtime discovery as a first class concern.
+
+> Amazon Resource Names (ARNs) are available at runtime to all Lambda functions defined in the same Architect project manifest. Things such as DynamoDB tables, SNS topics, SQS queues, API Gateway endpoints, and S3 static bucket ARNs are baked into `@architect/functions` so your runtime program logic interacts with resources using readable, people-friendly names defined in your Architect project manifest.
+
+`arc.services` retrieves the Architect service map: an object mapping the plugins and out-of-the-box Architect infrastructure that makes up the application.
 
 This object is lazily-loaded and cached, and thus the first call may incur a delay as the service map is populated (use of [`arc.events`](#arc.events), [`arc.queues`](#arc.queues) and [`arc.tables`](#arc.tables) transparently uses this method in the background).
 
-`arc.services` returns a service map object, with keys equaling any out-of-the-box Architect infrastructure types or plugins used by the Architect application. An example service map for an application composed of `@static`, `@events` and an `imagebucket` plugin would have the following structure:
+`arc.services` returns a service map object, with keys equaling any out-of-the-box Architect infrastructure types or plugins used by the Architect application. 
+
+#### Examples
+
+An example service map for an application composed of `@static`, `@events` and an `imagebucket` plugin would have the following structure:
 
 ```javascript
 let arc = require('@architect/functions')
 
 let services = await arc.services()
-console.log(services)
-/* logs out:
+/*
 {
   // a plugin named 'imagebucket' exposing some service discovery variables
   imagebucket: {
@@ -460,14 +447,11 @@ console.log(services)
 */
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
-### `arc.static`
+### `arc.static()`
 
 Returns the path of a given static asset, intended for use with static asset fingerprinting (`@static fingerprint true`).
-
-
-#### API
 
 Accepts two parameters:
 - `asset` - **string**
@@ -476,8 +460,7 @@ Accepts two parameters:
   - `stagePath` - **boolean**
     - `REST` API compatibility option, enables prepending of the API stage
 
-
-##### Examples
+#### Examples
 
 ```javascript
 let css = arc.static('/index.css')
@@ -487,30 +470,36 @@ let js = arc.static('/index.js', { stagePath: true })
 // '/staging/_static/index-b2c3d4.js'
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
-### `arc.tables`
+### `arc.tables()`
 
-Creates a DynamoDB client for your application's `@tables`. The client is an object, containing a nested object for each table; each table has the following methods:
+Creates a DynamoDB client for your application's `@tables`. The client is an object, containing a nested object for each table.
 
+#### Instance Methods
+
+Each table has the following methods:
+
+- `delete(key[, callback]) → [Promise]`
+  - Delete a record
+  - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#delete-property)
 - `get(key[, callback]) → [Promise]`
   - Get a single row by primary key (and secondary index)
   - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#get-property)
+- `put(record[, callback]) → [Promise]`
+  - Create or replace a record
+  - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property)
 - `query(query[, callback]) → [Promise]`
   - Query a table by passing a full document query object
   - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#query-property)
 - `scan([options][, callback]) → [Promise]`
   - Scan the entire table; accepts document filter object
   - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#scan-property)
-- `put(record[, callback]) → [Promise]`
-  - Create or replace a record
-  - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#put-property)
-- `delete(key[, callback]) → [Promise]`
-  - Delete a record
-  - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#delete-property)
 - `update(record[, callback]) → [Promise]`
   - Upsert a record; accepts document update object
   - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property)
+- `reflect`
+  - TODO
 - `name(tablename)`
   - Helper function that accepts a table name string, and returns an AWS resource name when you need to go lower level
     - For example use `data.name('my-table')` to get the human-unfriendly AWS name of the `my-table` `@table` resource
@@ -520,10 +509,9 @@ Creates a DynamoDB client for your application's `@tables`. The client is an obj
 - `_doc(thing[, callback]) → [Promise]`
   - An instance of [`AWS.DynamoDB.DocumentClient`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html)
 
-> The generated client is facade for <code>AWS.DynamoDB.DocumentClient</code>. The `delete` and `get` methods take a single parameter that is passed on to the `params.Key` attribute in the corresponding <code>DocumentClient</code> method. The `put` method takes a single parameter that is passed on as the `params.Item` attribute in the <code>DocumentClient.put</code> method. The `query`, `scan`, and `update` methods simply pass the `params` argument with the `TableName` parameter prepopulated. [See the official DynamoDB documentation for all available parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html).
+> The generated client is facade for `AWS.DynamoDB.DocumentClient`. The `delete` and `get` methods take a single parameter that is passed on to the `params.Key` attribute in the corresponding `DocumentClient` method. The `put` method takes a single parameter that is passed on as the `params.Item` attribute in the `DocumentClient.put` method. The `query`, `scan`, and `update` methods simply pass the `params` argument with the `TableName` parameter prepopulated. [See the official DynamoDB documentation for all available parameters](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html).
 
-
-##### Examples
+#### Examples
 
 Given the following `app.arc` file:
 
@@ -557,15 +545,18 @@ let data = await arc.tables()
 */
 ```
 
----
+<hr class="mt3 border-solid border0 border-b1" />
 
 ### `arc.ws`
 
-Send a message via WebSocket ([`@ws`](/docs/en/reference/project-manifest/ws)). An object containing two properties is required:
-- **`id`** (string) - API Gateway `connectionId` of the client you'd like to send the message to
-- **`payload`** (object or array) - payload to be sent (as JSON)
+Interact with WebSocket services. Declare endpoints with the [`@ws`](/docs/en/reference/project-manifest/ws) pragma.
 
-#### Examples
+#### Methods
+
+- `arc.ws.send`
+  - Send a message via WebSocket. An object containing two properties is required:
+  - **`id`** (string) - API Gateway `connectionId` of the client you'd like to send the message to
+  - **`payload`** (object or array) - payload to be sent (as JSON)
 
 ```javascript
 let arc = require('@architect/functions')
@@ -576,9 +567,51 @@ await arc.ws.send({
 })
 ```
 
----
+- `arc.ws.close`
+  - Close a WebSocket connection with the provided id:
+  - **`id`** (string) - API Gateway `connectionId` of the client you'd like to close
+
+```javascript
+let arc = require('@architect/functions')
+
+await arc.ws.close({ id: connectionId })
+```
+
+- `arc.ws.info`
+  - A pass-thru to the [ApiGatewayManagementApi#getConnection](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ApiGatewayManagementApi.html#getConnection-property) method.
+  - Retrieve information about the connection with the provided id:
+  - **`id`** (string) - API Gateway `connectionId` of the client you'd like get information about
+
+```javascript
+let arc = require('@architect/functions')
+
+let info = await arc.ws.info({ id: connectionId })
+/*
+{
+  ConnectedAt: <Date>,
+  Identity: {
+    SourceIp: <string>,
+    UserAgent: <string>,
+  },
+  LastActiveAt: <Date>,
+}
+*/
+```
+
+- `arc.ws._api`
+  - Return the internal [`ApiGatewayManagementApi`](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/ApiGatewayManagementApi.html) instance from `aws-sdk`.
+
+```javascript
+let arc = require('@architect/functions')
+
+let wsApi = await arc.ws._api()
+```
+
+<hr class="mt3 border-solid border0 border-b1" />
 
 ## `@architect/asap`
+
+[View package source on GitHub](https://github.com/architect/asap/)
 
 ### Setup
 
@@ -588,7 +621,7 @@ Install the Architect static asset proxy (ASAP) for Node.js:
 npm install @architect/asap
 ```
 
-### API
+### Parameters
 
 ASAP takes an optional configuration object with the following properties and returns an `async` Lambda handler:
 
@@ -615,8 +648,7 @@ ASAP takes an optional configuration object with the following properties and re
 - `spa` - **boolean** (defaults to `false`)
   - Enable single page app mode, all page requests deliver `/index.html`
 
-
-##### Examples
+### Examples
 
 ```javascript
 // basic usage

--- a/src/views/docs/en/reference/runtime-helpers/node.js.md
+++ b/src/views/docs/en/reference/runtime-helpers/node.js.md
@@ -1,7 +1,7 @@
 ---
-title: Node.js
-category: Runtime
-description: Node.js runtime helpers
+title: Node.js runtime helpers
+category: Runtime helpers
+description: Node.js runtime support
 ---
 
 Architect runtime helpers are optional, and designed to make it significantly easier to work with AWS CloudFormation provisioned resources and related assets.

--- a/src/views/docs/en/reference/runtime-helpers/node.js.md
+++ b/src/views/docs/en/reference/runtime-helpers/node.js.md
@@ -499,7 +499,7 @@ Each table has the following methods:
   - Upsert a record; accepts document update object
   - [Additional documentation](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB/DocumentClient.html#update-property)
 - `reflect`
-  - TODO
+  - 
 - `name(tablename)`
   - Helper function that accepts a table name string, and returns an AWS resource name when you need to go lower level
     - For example use `data.name('my-table')` to get the human-unfriendly AWS name of the `my-table` `@table` resource

--- a/src/views/docs/en/reference/runtime-helpers/python.md
+++ b/src/views/docs/en/reference/runtime-helpers/python.md
@@ -1,6 +1,6 @@
 ---
-title: Python
-category: Runtime
+title: Python runtime helpers
+category: Runtime helpers
 description: Python runtime support
 ---
 

--- a/src/views/docs/en/reference/runtime-helpers/ruby.md
+++ b/src/views/docs/en/reference/runtime-helpers/ruby.md
@@ -1,6 +1,6 @@
 ---
-title: Ruby
-category: Runtime
+title: Ruby runtime helpers
+category: Runtime helpers
 description: Ruby runtime support
 ---
 

--- a/src/views/modules/components/document-outline.js
+++ b/src/views/modules/components/document-outline.js
@@ -1,0 +1,24 @@
+export default function DocumentOutline (props = {}) {
+  const {
+    docOutline = '',
+    titleSlug = '',
+    title = 'Top',
+  } = props
+
+  return `
+<div class="pl0 w-toc sticky top0 right-sidebar">
+  <div class="pt0 ml-none-lg">
+    <a
+      id="top-link"
+      href="#${titleSlug}"
+      class="block mb-1 font-bold text-p1 text-h1"
+    >
+      ↑ ${title}
+    </a>
+    ${docOutline.replace(/class="mb1"/g, 'class="list-none"')}
+  </div>
+</div>
+  `
+}
+
+

--- a/src/views/modules/document/html.js
+++ b/src/views/modules/document/html.js
@@ -1,4 +1,5 @@
 import Banner from '../components/banner.js'
+import DocumentOutline from '../components/document-outline.js'
 import EditLink from '../components/edit-link.js'
 import Head from './head.js'
 import Script from './script.js'
@@ -12,8 +13,8 @@ export default function HTML (props = {}) {
     children = [],
     editURL = '',
     lang = 'en',
-    pageToC = '',
     scripts = '',
+    titleSlug = '',
     state = {},
     thirdparty = '',
     title = ''
@@ -62,6 +63,7 @@ ${Symbols}
         "
       >
         <h1
+          id="${titleSlug}"
           class="
             mb1
             font-semibold
@@ -75,12 +77,7 @@ ${Symbols}
           ${EditLink({ editURL })}
         </div>
       </div>
-      <div class="pl0 w-toc sticky top0 right-sidebar">
-        <h4>Table of Contents</h4>
-        <div class="pt0 ml-none-lg">
-          ${pageToC.replace(/class="mb1"/g, 'class="list-none"')}
-        </div>
-      </div>
+      ${DocumentOutline(props)}
     </main>
   </div>
   ${stateTag}


### PR DESCRIPTION
lots of hierarchy adjustment and rewording headings
add docs for `arc.ws`, `.tables`, and others

a few other small changes divided into separate commits with updates to deps and improvements for the document outline

<details open>

<summary>Preview</summary>

The page is too long for Firefox to correctly capture 😧 

![image](https://user-images.githubusercontent.com/15697/145147234-245f62f8-626b-4209-8a5a-27521846e958.png)

</details>