### PR TITLE
add requirements to local development doc

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "eslint": "^8.4.1",
     "linkinator": "^2.16.2",
     "spellchecker-cli": "^4.8.1",
-    "tap-arc": "^0.1.1",
+    "tap-arc": "^0.1.2",
     "tape": "^5.3.2",
     "tiny-json-http": "^7.3.1"
   },

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -13,7 +13,7 @@ Fast local development creates a tighter feedback loop maximizing developer velo
 - **Function runtimes & package managers:**
   - Node.js (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)) with [`npm`](https://www.npmjs.com/) 6+ or [`yarn`](https://yarnpkg.com/) 1+
   - Python (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)) and optionally [`pip3`](https://pip.pypa.io/en/stable/)
-  - Ruby (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) and optionally [`bundle`](https://bundler.io/)
+  - Ruby (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)) and optionally [`bundle`](https://bundler.io/)
 
 ## Preview
 

--- a/src/views/docs/en/guides/developer-experience/local-development.md
+++ b/src/views/docs/en/guides/developer-experience/local-development.md
@@ -6,6 +6,15 @@ description: How to develop locally with Architect sandbox
 
 Fast local development creates a tighter feedback loop maximizing developer velocity.
 
+## Requirements
+
+- **Platforms:** Linux, macOS, Windows
+- **Architect runtime:** Node.js 14+
+- **Function runtimes & package managers:**
+  - Node.js (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)) with [`npm`](https://www.npmjs.com/) 6+ or [`yarn`](https://yarnpkg.com/) 1+
+  - Python (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)) and optionally [`pip3`](https://pip.pypa.io/en/stable/)
+  - Ruby (optional, [supported versions](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) and optionally [`bundle`](https://bundler.io/)
+
 ## Preview
 
 Follow the [quickstart](/docs/en/get-started/quickstart) to get everything wired up. To preview a project running locally in a web browser:


### PR DESCRIPTION
On occasion new users are unsure of local prereqs. Is this a good place for now?

In #411 I think this fits into "App Development Guide" > "Working Locally" and/or "Home" > "Installation"
 
fixes #456
