### PR TITLE
Abstract out renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,10 @@
     "@architect/syntaxes": "github:architect/syntaxes#v1.2.1",
     "@toycode/markdown-it-class": "^1.2.4",
     "esm": "^3.2.25",
+    "front-matter": "^4.0.2",
     "highlight.js": "^11.3.1",
-    "js-yaml": "^4.1.0",
     "markdown-it": "^12.2.0",
     "markdown-it-external-anchor": "^1.0.0",
-    "markdown-it-front-matter": "^0.2.3",
     "markdown-it-toc-and-anchor": "^4.2.0",
     "slugify": "^1.6.3"
   },

--- a/src/http/get-docs-000lang-catchall/renderer.js
+++ b/src/http/get-docs-000lang-catchall/renderer.js
@@ -1,0 +1,43 @@
+const { escape } = require('querystring')
+const frontmatter = require('front-matter')
+const Markdown = require('markdown-it')
+const markdownClass = require('@toycode/markdown-it-class')
+const markdownExternalAnchor = require('markdown-it-external-anchor')
+const markdownToC = require('markdown-it-toc-and-anchor').default
+
+const classMapping = require('./markdown-class-mappings')
+const { escapeHtml } = Markdown().utils
+const hljs = require('./highlight')
+const highlight = require('./highlighter').bind(null, hljs, escapeHtml)
+
+// reproduces the slugify algorithm used in markdown-it-external-anchor
+const slugify = (s) => escape(String(s).trim().toLowerCase().replace(/\s+/g, '-').replace(/\(\)/g, ''))
+
+module.exports = function (fileContents) {
+  let docOutline = ''
+  const markdown = new Markdown({
+    linkify: true,
+    html: true,
+    typographer: true,
+    highlight
+  })
+    .use(markdownClass, classMapping)
+    .use(markdownExternalAnchor)
+    .use(markdownToC, {
+      anchorLink: false,
+      slugify,
+      tocClassName: 'pageToC',
+      tocFirstLevel: 2,
+      tocLastLevel: 6,
+      tocCallback: (tocMarkdown, tocArray, tocHtml) => { docOutline = tocHtml }
+    })
+  const { attributes, body } = frontmatter(fileContents)
+  const children = markdown.render(body)
+
+  return {
+    ...attributes,
+    children,
+    docOutline,
+    titleSlug: slugify(attributes.title),
+  }
+}

--- a/test/backend/renderer-test.js
+++ b/test/backend/renderer-test.js
@@ -1,0 +1,50 @@
+const test = require('tape')
+const render = require('../../src/http/get-docs-000lang-catchall/renderer')
+
+const TITLE = 'Test Doc'
+const TITLE_SLUG = 'test-doc'
+const CATEGORY = 'Testing'
+const DESCRIPTION = 'Make sure we get Markdown'
+const file = `
+---
+title: ${TITLE}
+category: ${CATEGORY}
+description: ${DESCRIPTION}
+---
+
+> Architect is a simple tool to build and deliver powerful cloud function-based web apps and APIs
+
+## Create a new project
+
+\`\`\`arc
+@app
+
+@http
+get /
+\`\`\`
+
+## Deploy to AWS
+
+[AWS is great](https://aws.amazon.com/)
+
+### $ubsection 2.1?
+
+## Section 3
+`.trim()
+
+test('custom Markdown renderer', (t) => {
+  const result = render(file)
+
+  t.equal(result.title, TITLE, 'title attribute is present')
+  t.equal(result.category, CATEGORY, 'category attribute is present')
+  t.equal(result.description, DESCRIPTION, 'description attribute is present')
+  t.equal(result.titleSlug, TITLE_SLUG, 'titleSlug attribute is generated')
+  t.ok(typeof result.docOutline === 'string', 'docOutline is a string of HTML')
+  t.ok(typeof result.children === 'string', 'children is a string of HTML')
+  t.ok(result.children.indexOf('id="create-a-new-project"') > 0, 'Headings are linkified')
+  t.ok(result.children.indexOf('id="%24ubsection-2.1%3F"') > 0, 'Complex headings are linkified')
+  t.ok(result.children.indexOf('target="_blank">AWS is great</a>') > 0, 'External link targets = blank')
+  t.ok(result.children.indexOf('<pre class="hljs ') > 0, 'highlight.js is working')
+
+  t.end()
+})


### PR DESCRIPTION
move renderer to separate, testable file. the main index.js was getting a bit long
also, I opted for the `front-matter` lib to cut down on complexity.