### PR TITLE
Add local prefs info to relevant CLI docs

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -92,6 +92,13 @@ label.sidebar-group-title + ul {
   }
 }
 
+li > ul.mb1 {
+  margin-bottom: 0;
+}
+li > ol.mb1 {
+  margin-bottom: 0;
+}
+
 details > summary {
   list-style: none;
 }

--- a/src/http/get-docs-000lang-catchall/markdown-class-mappings.js
+++ b/src/http/get-docs-000lang-catchall/markdown-class-mappings.js
@@ -25,6 +25,9 @@ module.exports = {
   p: [
     'mb-1'
   ],
+  ol: [
+    'mb1'
+  ],
   ul: [
     'mb1'
   ],

--- a/src/views/docs/en/reference/cli/deploy.md
+++ b/src/views/docs/en/reference/cli/deploy.md
@@ -28,6 +28,23 @@ arc deploy [--production|--static|--direct]
 - `[--dry-run]` Creates a CloudFormation template but does not deploy it. A dry-run allows you to check the CloudFormation and SAM output before deploying the actual stack.
 - `[--verbose, -v]` Displays the full deploy status messages.
 
+## Local preferences: `@create`
+
+When deploying, Architect can automatically scaffold resources (via [`arc init`](./init)) found in the [application's manifest](../../get-started/project-manifest) that do not yet exist. Options are set with [`@create` in local preferences](../configuration/local-preferences#%40create).
+
+- `autocreate` - Set to `true` to enable automatic creation of boilerplate Lambda handlers and static assets if they do not exist.
+- `templates` - Specify templates for automatic resource scaffolding.
+  - `<pragma name> path/to/template.ext`
+  - Does not enable `autocreate`
+
+```arc
+@create
+autocreate true
+templates
+  http path/to/template/http.js
+  events path/to/template/events.py
+```
+
 ## Examples
 
 ### Deploy a staging stack

--- a/src/views/docs/en/reference/cli/env.md
+++ b/src/views/docs/en/reference/cli/env.md
@@ -6,7 +6,7 @@ description: Read and write environment variables for Lambda functions.
 
 Read and write environment variables. This allows apps to centrally store sensitive configuration data, such as API keys, outside of the codebase in revision control.
 
-> `arc env` will **not** upload variables from a project's local [`preferences.arc`](../configuration/local-preferences#%40env); however, it will download variables from AWS and overwrite local preferences.
+> `arc env` will **not** upload variables from a project's [local preferences file](../configuration/local-preferences#%40env); however, it will download variables from AWS and overwrite local preference entries.
 
 ## Usage
 

--- a/src/views/docs/en/reference/cli/init.md
+++ b/src/views/docs/en/reference/cli/init.md
@@ -18,6 +18,20 @@ arc init [--static|--runtime]
 - `[--runtime, -r]` Create a new project with a specified runtime, options are node, deno, python, or ruby
 - `[--verbose, -v]` Even more output
 
+## Local preferences: `@create`
+
+`arc init` can use specified templates when scaffolding new resources. Options are set with [`@create` in local preferences](../configuration/local-preferences#%40create).
+
+- `templates` - Specify templates for automatic resource scaffolding.
+  - `<pragma name> path/to/template.ext`
+
+```arc
+@create
+templates
+  http path/to/template/http.js
+  events path/to/template/events.py
+```
+
 ## Examples
 
 ### Create a new app

--- a/src/views/docs/en/reference/cli/sandbox.md
+++ b/src/views/docs/en/reference/cli/sandbox.md
@@ -28,17 +28,43 @@ arc sandbox [--port|--disable-symlinks|--no-hydrate|--verbose]
 - `[--disable-symlinks]` Disable symlinking `src/shared` and copy instead
 - `[--no-hydrate]` Disables hydration
 
-### Local preferences
+### CLI variables
 
-Sandbox will take into account Architect [local preferences](../configuration/local-preferences).
+The following variables can be set on the command line when running `arc sandbox`. Other variables will be ignored by Sandbox.
 
-#### `@sandbox`
+- `NODE_ENV` - `testing|staging|production`
+  - Defaults to `testing`
+- `ARC_API_TYPE` - Set the API Gateway API type
+  - Can be one of `http` (aliased to `httpv2`), `httpv1`, `rest`
+  - Defaults to `http`
+- `PORT` - Manually specify HTTP port
+  - Defaults to `3333`
+- `ARC_LOCAL`- If present and used in conjunction with `NODE_ENV=staging|production`, emulates live `staging` or `production` environment
+  - Uses your [local preferences `@env`](../configuration/local-preferences#%40env) environment variables for the appropriate stage
+  - Connects Sandbox to live AWS events and DynamoDB infrastructure
+  - Requires valid AWS credentials with the same profile name as defined in your [project manifest](../project-manifest/aws#profile)
+- `ARC_QUIET` - If present, disable (most) logging
 
-The following can be set as a part of the [`@sandbox`](../configuration/local-preferences#sandbox) pragma.
+#### Example
 
-- `env`<sup>*</sup> - Override the local environment setting to use `staging` or `production` so that Sandbox uses that stage's environment variables as set in local preferences `@env` or in the project's `.env` file.
+Run Sandbox in quiet mode on a different port:
+
+```bash
+ARC_QUIET=1 PORT=8888 npx arc sandbox
+```
+
+## Local preferences
+
+Several Architect [local preferences](../configuration/local-preferences) can be leveraged to change how Sandbox works while developing locally.
+
+### `@sandbox`
+
+The following can be set as a part of the [`@sandbox`](../configuration/local-preferences#%40sandbox) pragma.
+
+- `env`<sup>*</sup> - Override the local environment setting to use `staging` or `production` so that Sandbox uses that stage's environment variables as set in [local preferences `@env`](../configuration/local-preferences#%40env) or in the project's `.env` file.
   - Can be one of `testing` (default), `staging`, or `production`
-- `useAws`<sup>*</sup> - Use live AWS infrastructure from Sandbox. Specifically, `@tables`, `@tables-indexes`, `@events`, and `@queues`. Uses the `staging` environment by default, but `env` can be set to `production`.
+- `useAws`<sup>*</sup> - Use live AWS infrastructure from Sandbox. Specifically, `@tables`, `@tables-indexes`, `@events`, and `@queues`.
+  - Uses the `staging` environment by default, but `env` can be set to `production`.
   - Defaults to `false`
 - `no-hydrate` - Disable [function hydration](./hydrate) on Sandbox start.
   - Defaults to `false`
@@ -52,9 +78,9 @@ no-hydrate true
 
 \* These advanced options should be used with care since they will allow local development code to interact with live AWS resources.
 
-#### `@sandbox-startup`
+### `@sandbox-startup`
 
-Additionally, Sandbox can run shell commands on startup by setting [`@sandbox-startup`](../configuration/local-preferences#sandbox-startup) in [local preferences](../configuration/local-preferences).
+Additionally, Sandbox can run shell commands on startup by setting [`@sandbox-startup`](../configuration/local-preferences#%40sandbox-startup) in [local preferences](../configuration/local-preferences).
 
 ```arc
 @sandbox-startup
@@ -62,23 +88,77 @@ node scripts/seed_db.js
 echo 'hello'
 ```
 
-### Environment variables
+### `@create`
 
-- `NODE_ENV` - `testing|staging|production`
-  - Defaults to `testing`
-- `ARC_API_TYPE` - Set the API Gateway API type
-  - Can be one of `http` (aliased to `httpv2`), `httpv1`, `rest`
-  - Defaults to `http`
-- `PORT` - Manually specify HTTP port
-  - Defaults to `3333`
-- `ARC_LOCAL`- If present and used in conjunction with `NODE_ENV=staging|production`, emulates live `staging` or `production` environment
-  - Uses your local preferences `@staging` or `@production` environment variables
-  - Connects Sandbox to live AWS events and DynamoDB infrastructure
-  - Requires valid AWS credentials with the same profile name as defined in your [project manifest](../project-manifest/aws#profile)
-- `ARC_QUIET` - If present, disable (most) logging
+Upon starting, Sandbox can automatically scaffold resources (via [`arc init`](./init)) found in the [application's manifest](../../get-started/project-manifest) that do not yet exist. Options are set with [`@create` in local preferences](../configuration/local-preferences#%40create).
 
+- `autocreate` - Set to `true` to enable automatic creation of boilerplate Lambda handlers and static assets if they do not exist.
+- `templates` - Specify templates for automatic resource scaffolding.
+  - `<pragma name> path/to/template.ext`
+  - Does not enable `autocreate`
 
-### Local Database
+```arc
+@create
+autocreate true
+templates
+  http path/to/template/http.js
+  events path/to/template/events.py
+```
+
+### `@env`
+
+Architect Sandbox will load variables for Sandbox's current environment (`testing`, `staging`, or `production`) from a [local preferences file with `@env`](../configuration/local-preferences#%40env). If a project contains a `.env` file, Architect will load those variables _instead_.
+
+Variables from local preference files and `.env` will **not** be merged. Further details, including the variable load-strategy are [outlined below](#environment-variables).
+
+## Environment variables
+
+Sandbox automatically loads environment variables for availability at runtime (`process.env.MY_VAR` in Node.js). Environment variables can be set in a few locations. It's important to understand how each source is prioritized when developing locally.
+
+### Load strategy
+
+Sandbox will prioritize...
+
+1. a project's `.env` file (if it exists),
+2. then project-level Architect preferences,
+3. and finally global Architect preferences. 
+
+Variables across these sources are **not** merged.
+
+Using a [local preferences file with `@env`](../configuration/local-preferences#%40env) offers the most flexibility since variables can be specified per environment: `testing`, `staging`, and `production`.
+
+### Example scenario
+
+If `.env` is found, Sandbox will not load any variables from any Arc preferences. Given the following case with 3 environment variable sources:
+
+```bash
+# ./.env
+URL="https://arc.codes"
+```
+
+```arc
+# ./prefs.arc
+@env
+testing
+  URL www.architect.fake
+```
+
+```arc
+# ~/.preferences.arc
+@env
+testing
+  URL ftp://arc.ftp
+  ADMIN_PASS zero cool
+```
+
+The following is true in a Node.js function run with Sandbox:
+
+```js
+process.env.URL === 'https://arc.codes' // true
+process.env.ADMIN_PASS // undefined
+```
+
+## Local Database
 
 Sandbox creates an in-memory instance of [dynalite](https://github.com/mhart/dynalite) with `@tables` and `@tables-indexes` found in the `app.arc` file. `@tables-streams` is not currently supported by dynalite.
 
@@ -86,7 +166,7 @@ When Sandbox is terminated, any data written is cleared from memory.
 
 You can set a custom port by using an environment variable: `ARC_TABLES_PORT=5555`.
 
-#### Live database example
+### Live database example
 
 Connect Sandbox to the DynamoDB staging database on AWS:
 

--- a/src/views/docs/en/reference/cli/sandbox.md
+++ b/src/views/docs/en/reference/cli/sandbox.md
@@ -21,14 +21,14 @@ Architect projects work locally and offline. Sandbox emulates most app resources
 arc sandbox [--port|--disable-symlinks|--no-hydrate|--verbose]
 ```
 
-### Flags
+## Flags
 
 - `[--port, -p]` Manually specify HTTP port (default `3333`)
 - `[--verbose, -v]` Enable verbose logging
 - `[--disable-symlinks]` Disable symlinking `src/shared` and copy instead
 - `[--no-hydrate]` Disables hydration
 
-### CLI variables
+## CLI variables
 
 The following variables can be set on the command line when running `arc sandbox`. Other variables will be ignored by Sandbox.
 
@@ -45,7 +45,7 @@ The following variables can be set on the command line when running `arc sandbox
   - Requires valid AWS credentials with the same profile name as defined in your [project manifest](../project-manifest/aws#profile)
 - `ARC_QUIET` - If present, disable (most) logging
 
-#### Example
+### Example
 
 Run Sandbox in quiet mode on a different port:
 
@@ -158,7 +158,7 @@ process.env.URL === 'https://arc.codes' // true
 process.env.ADMIN_PASS // undefined
 ```
 
-## Local Database
+## Local database
 
 Sandbox creates an in-memory instance of [dynalite](https://github.com/mhart/dynalite) with `@tables` and `@tables-indexes` found in the `app.arc` file. `@tables-streams` is not currently supported by dynalite.
 


### PR DESCRIPTION
Mostly this updates the `sandbox` doc with a "Local preferences" section to help explain how prefs.arc entries interact with Sandbox.

I also added short entries to other CLI docs where the command can be affected by local preferences. Like `@create` + `arc init`

New Sandbox doc outline
<img width="945" alt="image" src="https://user-images.githubusercontent.com/15697/154194319-f291b288-0cbc-487d-8028-df494be6370a.png">
