### PR TITLE
update sharing code, shared, and views docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@architect/architect": {
-      "version": "10.0.5",
-      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-10.0.5.tgz",
-      "integrity": "sha512-i2i1/znCyd0/KSMorFejuaZ8lC/ZGciqZ0Xv4d+L+hjIHcUJViDvA9dKuaSPZ05s3OhsJ0SJcTLfHV2ZLDRNng==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-10.1.0.tgz",
+      "integrity": "sha512-ChU0i7uWZaubHHqBLSz5Btn+tWq5s3Ac6Mth1lWhfiZOUJ6/NpiScSYr3VLREbhwPNcqx7KE5RWXRzJGPoLjBQ==",
       "dev": true,
       "requires": {
         "@architect/create": "4.0.2",
@@ -16,7 +16,7 @@
         "@architect/env": "3.0.0",
         "@architect/hydrate": "3.0.1",
         "@architect/logs": "4.0.0",
-        "@architect/sandbox": "5.1.1",
+        "@architect/sandbox": "5.2.0",
         "aws-sdk": "2.1001.0",
         "chalk": "4.1.2",
         "update-notifier": "5.1.0"
@@ -211,13 +211,13 @@
       }
     },
     "@architect/sandbox": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@architect/sandbox/-/sandbox-5.1.1.tgz",
-      "integrity": "sha512-41Y5J4LL/VD2BKn8GxJpFVYBznyaIqHddDl90gv/1o3NGS9EgJBggv89EasyRpAwQcOscsCRhFtYEYjEFnSJTQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@architect/sandbox/-/sandbox-5.2.0.tgz",
+      "integrity": "sha512-9d07GUMvl7gaMDYzDjj+NxXR+XG0XKlJRy9wn7HWFgU58iKGVaoWf3ScQSPWW8MqyHrNn2bMLoLFiH50n27p/A==",
       "dev": true,
       "requires": {
-        "@architect/asap": "~5.0.0",
-        "@architect/create": "~4.0.0",
+        "@architect/asap": "~5.0.1",
+        "@architect/create": "~4.0.2",
         "@architect/hydrate": "~3.0.1",
         "@architect/inventory": "~3.0.0",
         "@architect/utils": "~3.1.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "tiny-frontmatter": "^1.0.0"
   },
   "devDependencies": {
-    "@architect/architect": "^10.0.5",
+    "@architect/architect": "^10.1.0",
     "@architect/eslint-config": "^2.0.1",
     "@architect/spellcheck-dictionary": "git+https://github.com/architect/spellcheck-dictionary.git",
     "eslint": "^8.10.0",

--- a/src/shared/redirect-map.js
+++ b/src/shared/redirect-map.js
@@ -40,6 +40,16 @@ const tempRedirects = {
   '/@views': '/docs/en/reference/project-manifest/views',
   '/ws':  '/docs/en/reference/project-manifest/ws',
   '/@ws': '/docs/en/reference/project-manifest/ws',
+
+  // Runtimes
+  '/node': '/docs/en/reference/runtime-helpers/node.js',
+  '/ruby': '/docs/en/reference/runtime-helpers/ruby',
+  '/python': '/docs/en/reference/runtime-helpers/python',
+  '/deno': '/docs/en/reference/runtime-helpers/deno',
+
+  // Other aliases
+  '/typescript': '/docs/en/guides/developer-experience/using-typescript',
+  '/esm': '/docs/en/guides/developer-experience/using-esm',
 }
 
 // redirect known v5/6 arc urls to v8 and then to v9

--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -9,24 +9,81 @@ sections:
   - src/views
 ---
 
-Architect makes it easy to share code across many Lambda functions. Apps most commonly need to share business logic and view templates so Architect provides `@shared` and `@views` capability. Architect copies the contents of `src/shared` into all Lambdas and `src/views` into Lambda functions wired to respond to `@http` GET requests.
+Architect makes it easy to share code across Lambda functions. The most common use case is to share business logic and view templates. Architect has [`@shared`](../../reference/project-manifest/shared) and [`@views`](../../reference/project-manifest/views) pragmas to provide this functionality.
 
-Example `app.arc`
+Architect automatically copies the contents of `src/shared` into all Lambdas and `src/views` into `@http` GET Lambda functions.
+
+## Example usage
+
+Given a simple `app.arc` where `@shared` and `@views` are declared:
 
 ```arc
 @app
 myapp
 
 @shared
-src src/shared # this is the default
 
 @views
-src src/views # this is the default
 
 @http
 get /
 post /like
 ```
+
+Where utility code lives in `./src/shared` and common view code in `.src/views`:
+
+```sh
+.
+├── src
+│   ├── http
+│   │   ├── get-index/index.js
+│   │   └── post-like/index.js
+│   └── shared
+│       └── authenticate.js
+│   └── views
+│       └── document.js
+└── app.arc
+```
+
+`get-index` can use shared code by requiring it from `@architect/shared/<file>` and views code from `@architect/views/<file>`:
+
+```js
+// get-index/index.js
+const auth = require('@architect/shared/authenticate')
+const document = require('@architect/views/document')
+```
+
+The `post-like` route has access to shared code as well, but not views because it does not respond to a GET request.
+
+```js
+// post-like/index.js
+const auth = require('@architect/shared/authenticate')
+```
+
+## Custom shared paths
+
+The default shared and views directories can be overridden:
+
+```arc
+@app
+myapp
+
+@shared
+src path/to/shared
+
+@views
+src path/to/views
+```
+
+They are still required in the same way:
+
+```js
+// get-index/index.js
+const auth = require('@architect/shared/authenticate')
+const document = require('@architect/views/document')
+```
+
+## Runtime details
 
 No matter where `@shared` source is configured it gets copied to every Lambda. The destination is slightly different depending on runtime:
 
@@ -46,6 +103,6 @@ Likewise, `@views` runtime destinations:
 
 > Tip: the entire contents of `src/shared` are copied so we strongly suggest keeping the directory structure as flat as possible, and the payloads as small as possible to ensure the best performance.
 
-## Dependencies
+## Shared code dependencies
 
-`@shared` and `@views` support having their own dependencies defined by `package.json`, `requirements.txt` or `Gemfile`.
+`@shared` and `@views` resources can have their own dependencies defined by `package.json`, `requirements.txt` or `Gemfile`. These dependencies will also be copied to corresponding Lambdas.

--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -9,9 +9,9 @@ sections:
   - src/views
 ---
 
-Architect makes it easy to share code across Lambda functions. The most common use case is to share business logic and view templates. Architect has [`@shared`](../../reference/project-manifest/shared) and [`@views`](../../reference/project-manifest/views) pragmas to provide this functionality.
+Architect makes it easy to share code across Lambda functions. Share business logic across functions with the [`@shared`](../../reference/project-manifest/shared) pragma and view templates with the [`@views`](../../reference/project-manifest/views) pragma.
 
-Architect automatically copies the contents of `src/shared` into all Lambdas and `src/views` into `@http` GET Lambda functions.
+Enabling these features instructs Architect to automatically copy the contents of `./src/shared` into all Lambdas and `./src/views` into `@http` GET Lambda functions.
 
 ## Example usage
 
@@ -71,8 +71,8 @@ const document = require('@architect/views/document')
 
 ```rb
 # get-index/index.rb
-require 'architect/shared/authenticate'
-require 'architect/views/document'
+require_relative './vendor/shared/authenticate'
+require_relative './vendor/views/document'
 ```
 
 </div>
@@ -84,8 +84,8 @@ require 'architect/views/document'
 
 ```py
 # get-index/index.py
-from arc.shared import authenticate
-from arc.views import document
+import vendor.shared.authenticate
+import vendor.views.document
 ```
 
 </div>
@@ -117,7 +117,7 @@ const auth = require('@architect/shared/authenticate')
 
 ```rb
 # post-like/index.rb
-require 'architect/shared/authenticate'
+require_relative './vendor/shared/authenticate'
 ```
 
 </div>
@@ -129,7 +129,7 @@ require 'architect/shared/authenticate'
 
 ```py
 # post-like/index.py
-from arc.shared import authenticate
+import vendor.shared.authenticate
 ```
 
 </div>
@@ -177,8 +177,8 @@ const document = require('@architect/views/document')
 
 ```rb
 # get-index/index.rb
-require 'architect/shared/authenticate'
-require 'architect/views/document'
+require_relative './vendor/shared/authenticate'
+require_relative './vendor/views/document'
 ```
 
 </div>
@@ -190,8 +190,8 @@ require 'architect/views/document'
 
 ```py
 # get-index/index.py
-from arc.shared import authenticate
-from arc.views import document
+import vendor.shared.authenticate
+import vendor.views.document
 ```
 
 </div>

--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -36,16 +36,25 @@ Where utility code lives in `./src/shared` and common view code in `.src/views`:
 .
 ├── src
 │   ├── http
-│   │   ├── get-index/index.js
-│   │   └── post-like/index.js
-│   └── shared
-│       └── authenticate.js
+│   │   ├── get-index
+│   │   │   └── index(.js|.rb|.py)
+│   │   └── post-like
+│   │       └── index(.js|.rb|.py)
+│   ├── shared
+│   │   └── authenticate(.js|.rb|.py)
 │   └── views
-│       └── document.js
+│       └── document(.js|.rb|.py)
 └── app.arc
 ```
 
 `get-index` can use shared code by requiring it from `@architect/shared/<file>` and views code from `@architect/views/<file>`:
+
+<arc-viewer default-tab=js>
+<div slot=contents>
+
+<arc-tab label=js>
+<h5>js</h5>
+<div slot=content>
 
 ```js
 // get-index/index.js
@@ -53,12 +62,81 @@ const auth = require('@architect/shared/authenticate')
 const document = require('@architect/views/document')
 ```
 
+</div>
+</arc-tab>
+
+<arc-tab label=rb>
+<h5>rb</h5>
+<div slot=content>
+
+```rb
+# get-index/index.rb
+require 'architect/shared/authenticate'
+require 'architect/views/document'
+```
+
+</div>
+</arc-tab>
+
+<arc-tab label=py>
+<h5>py</h5>
+<div slot=content>
+
+```py
+# get-index/index.py
+from arc.shared import authenticate
+from arc.views import document
+```
+
+</div>
+</arc-tab>
+
+</div>
+</arc-viewer>
+
 The `post-like` route has access to shared code as well, but not views because it does not respond to a GET request.
+
+<arc-viewer default-tab=js>
+<div slot=contents>
+
+<arc-tab label=js>
+<h5>js</h5>
+<div slot=content>
 
 ```js
 // post-like/index.js
 const auth = require('@architect/shared/authenticate')
 ```
+
+</div>
+</arc-tab>
+
+<arc-tab label=rb>
+<h5>rb</h5>
+<div slot=content>
+
+```rb
+# post-like/index.rb
+require 'architect/shared/authenticate'
+```
+
+</div>
+</arc-tab>
+
+<arc-tab label=py>
+<h5>py</h5>
+<div slot=content>
+
+```py
+# post-like/index.py
+from arc.shared import authenticate
+```
+
+</div>
+</arc-tab>
+
+</div>
+</arc-viewer>
 
 ## Custom shared paths
 
@@ -77,11 +155,50 @@ src path/to/views
 
 They are still required in the same way:
 
+<arc-viewer default-tab=js>
+<div slot=contents>
+
+<arc-tab label=js>
+<h5>js</h5>
+<div slot=content>
+
 ```js
 // get-index/index.js
 const auth = require('@architect/shared/authenticate')
 const document = require('@architect/views/document')
 ```
+
+</div>
+</arc-tab>
+
+<arc-tab label=rb>
+<h5>rb</h5>
+<div slot=content>
+
+```rb
+# get-index/index.rb
+require 'architect/shared/authenticate'
+require 'architect/views/document'
+```
+
+</div>
+</arc-tab>
+
+<arc-tab label=py>
+<h5>py</h5>
+<div slot=content>
+
+```py
+# get-index/index.py
+from arc.shared import authenticate
+from arc.views import document
+```
+
+</div>
+</arc-tab>
+
+</div>
+</arc-viewer>
 
 ## Runtime details
 

--- a/src/views/docs/en/reference/project-manifest/shared.md
+++ b/src/views/docs/en/reference/project-manifest/shared.md
@@ -4,7 +4,7 @@ category: app.arc
 description: Configure <code>src/shared</code> code
 ---
 
-Configure the location of shared code.
+Configure the location of shared code. For a full example, see [Sharing Code](../../guides/developer-experience/sharing-code).
 
 ## Syntax
 

--- a/src/views/docs/en/reference/project-manifest/views.md
+++ b/src/views/docs/en/reference/project-manifest/views.md
@@ -7,6 +7,7 @@ description: Share view code across `@http` functions
 Configure the location of view code.
 Architect copies view code to all HTTP GET handler functions by default.
 You can also specify only the routes you want views copied to with the `@views` pragma.
+For a full example, see [Sharing Code](../../guides/developer-experience/sharing-code).
 
 ## Syntax
 


### PR DESCRIPTION
This expands the Sharing Code doc. I leaned toward over-explaining, so let me know if it's too heavy-handed.

This doesn't address sharing code in Typescript. That's for another PR