### PR TITLE
Add guide on AWS authentication via EC2 IAM role

### DIFF
--- a/src/views/docs/en/get-started/detailed-aws-setup.md
+++ b/src/views/docs/en/get-started/detailed-aws-setup.md
@@ -120,6 +120,50 @@ $env:AWS_REGION='us-west-1'
 
 > If you prefer, you can also use: *Control Panel » System » Advanced System Settings » Environment Variables*.
 
+If you're deploying from a CI/CD pipeline that runs on AWS EC2 instances and uses [IAM roles for EC2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html) to define the pipeline's permissions, you'll need to generate temporary credentials via the AWS SDK and use them to either define the AWS env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`) or write a credentials file as described above. Once the credentials are in a form that Architect can read, you can call the deploy command as normal.
+
+Below is a basic example using the AWS JS SDK that deploys a stack to the staging environment:
+
+```javascript
+const { exec } = require("child_process")
+const AWS = require("aws-sdk")
+
+// Assumes that you have a 'build' script defined in package.json for building
+// frontend assets.
+const DEPLOY_COMMAND = "npm run build && npx arc deploy"
+
+const deploy = () => {
+  // JS-specific: you need to execute the deployment command or script in a subprocess
+  // in order to have access to the updated env vars.
+  return exec(DEPLOY_COMMAND, (error, stdout, stderr) => {
+    console.log(stdout)
+
+    if (error) {
+      console.error(stderr)
+      console.error(error)
+      process.exit(error.code)
+    }
+  })
+}
+
+const deployWithAwsCredentials = (error, credentials) => {
+  if (error) {
+    console.error(error)
+    return process.exit(1)
+  }
+
+  process.env.AWS_ACCESS_KEY_ID =
+    process.env.AWS_ACCESS_KEY_ID || credentials.accessKeyId
+  process.env.AWS_SECRET_ACCESS_KEY =
+    process.env.AWS_SECRET_ACCESS_KEY || credentials.secretAccessKey
+  process.env.AWS_SESSION_TOKEN =
+    process.env.AWS_SESSION_TOKEN || credentials.sessionToken
+
+  return deploy()
+}
+
+AWS.config.getCredentials(deployWithAwsCredentials)
+```
 
 ### Install Architect
 


### PR DESCRIPTION
Follow up from issue [#1311](https://github.com/architect/architect/issues/1311)

Since Architect doesn't support using an EC2 IAM role to
authenticate AWS API calls, and adding support would require
big changes to core functionality, adding a note to the
documentation can help the occasional dev who finds themself
needing using this form of authentication.

Since this is principally an example of how to handle a particular
form of authentication, I included it in the section on setting
up AWS credentials. I made the example as simple as I could,
and wrote it in JS, because that's the language I'm using, so
it's the one that I've actually tested and seen work.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](/docs/en/about/contribute).

Thanks again!
