### PR TITLE
Add missing slash to file path

### DIFF
--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -30,7 +30,7 @@ get /
 post /like
 ```
 
-Where utility code lives in `./src/shared` and common view code in `.src/views`:
+Where utility code lives in `./src/shared` and common view code in `./src/views`:
 
 ```bash
 .


### PR DESCRIPTION
`.src` is not a thing, but `./src` is

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](/docs/en/about/contribute).

Thanks again!
