### PR TITLE
start new "Using Deno" doc 🦕

### DIFF
--- a/.github/workflows/link-checker.yaml
+++ b/.github/workflows/link-checker.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
       - run: npm i
       - run: npx arc hydrate
       - run: npm run link-checker

--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -30,7 +30,7 @@ get /
 post /like
 ```
 
-Where utility code lives in `./src/shared` and common view code in `.src/views`:
+Where utility code lives in `./src/shared` and common view code in `./src/views`:
 
 ```bash
 .

--- a/src/views/docs/en/guides/developer-experience/using-deno.md
+++ b/src/views/docs/en/guides/developer-experience/using-deno.md
@@ -1,0 +1,37 @@
+---
+title: Using Deno
+category: Developer Experience
+description: Deno runtime support
+---
+
+The Architect team has a strong interest in [Deno](https://deno.land/) 🦕 as a runtime.
+
+## Current support
+
+[Sandbox](../../reference/cli/sandbox) will use `deno` to invoke functions locally, but Deno is not currently an officially supported AWS Lambda runtime. It is possible to use a [Lambda _layer_](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-layer) to provide the Deno executable, but response times may suffer.
+
+### Sandbox configuration
+
+Set the Deno runtime in your [project (`app.arc`)](../../reference/project-manifest/aws) or [function (`config.arc`)](../configuration/function-config): config
+
+```arc
+@aws
+runtime deno
+```
+
+> 🥇  Make sure you [install Deno locally](https://deno.land/#installation). Architect and Sandbox will still run with Node.js, but will orchestrate `deno` processes when running your functions.
+
+### Lambda Deno layers
+
+Use Deno for deployed functions by specifying one of [these ARNs](https://github.com/beginner-corp/begin-deno-runtime) in your project or function [`layers` config](../../reference/configuration/function-config#layers):
+
+```arc
+@aws
+runtime deno
+layers
+  arn:aws:lambda:us-east-1:455488262213:layer:DenoRuntime:37
+```
+
+## Runtime helper
+
+Track [runtime helper](https://github.com/architect/functions-deno) progress.

--- a/src/views/docs/en/guides/developer-experience/using-deno.md
+++ b/src/views/docs/en/guides/developer-experience/using-deno.md
@@ -4,34 +4,30 @@ category: Developer Experience
 description: Deno runtime support
 ---
 
-The Architect team has a strong interest in [Deno](https://deno.land/) 🦕 as a runtime.
+The Architect team has a strong interest in [Deno](https://deno.land/) as a runtime.
 
 ## Current support
 
-[Sandbox](../../reference/cli/sandbox) will use `deno` to invoke functions locally, but Deno is not currently an officially supported AWS Lambda runtime. It is possible to use a [Lambda _layer_](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-layer) to provide the Deno executable, but response times may suffer.
+Deno is not currently an officially supported AWS Lambda runtime, but Architect can add a [Lambda _layer_](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-concepts.html#gettingstarted-concepts-layer) to provide the Deno executable on AWS infrastructure.  
+Additionally, [Sandbox](../../reference/cli/sandbox) will use `deno` to invoke functions while developing locally.
 
-### Sandbox configuration
+> ⚠️  Lambda layers can increase response times when the function is cold. This approach to enabling Deno is not ideal for user interaction.
 
-Set the Deno runtime in your [project (`app.arc`)](../../reference/project-manifest/aws) or [function (`config.arc`)](../configuration/function-config): config
+### Project configuration
+
+Set the Deno runtime in your [project (`app.arc`)](../../reference/project-manifest/aws) or [function (`config.arc`)](../configuration/function-config) configuration:
 
 ```arc
 @aws
 runtime deno
 ```
 
-> 🥇  Make sure you [install Deno locally](https://deno.land/#installation). Architect and Sandbox will still run with Node.js, but will orchestrate `deno` processes when running your functions.
+> 🦕  To enable Sandbox support for Deno, make sure you [install Deno locally](https://deno.land/#installation).  
 
-### Lambda Deno layers
+Architect and Sandbox will still run with Node.js, but will orchestrate `deno` processes when running your functions.
 
-Use Deno for deployed functions by specifying one of [these ARNs](https://github.com/beginner-corp/begin-deno-runtime) in your project or function [`layers` config](../../reference/configuration/function-config#layers):
+### Deno runtime version
 
-```arc
-@aws
-runtime deno
-layers
-  arn:aws:lambda:us-east-1:455488262213:layer:DenoRuntime:37
-```
+The current provided layer is Deno v1.19.1.
 
-## Runtime helper
-
-Track [runtime helper](https://github.com/architect/functions-deno) progress.
+> 🧑‍🔬  The Arc team is actively working on providing up-to-date and configurable Deno layers.

--- a/src/views/docs/table-of-contents.mjs
+++ b/src/views/docs/table-of-contents.mjs
@@ -17,6 +17,7 @@ const Guides = [
       'Logging & monitoring',
       'Using ESM',
       'Using TypeScript',
+      'Using Deno',
       'Customizing CloudFormation',
       {
         'Continuous integration': [


### PR DESCRIPTION
Describe current status of Deno support.

I deliberately didn't include `deno` in `@aws: { runtime: }` docs yet since there are still some serious caveats, namely the default layer and the performance cost.