### PR TITLE
Pointing links to correct page

### DIFF
--- a/src/views/docs/en/reference/project-manifest/plugins.md
+++ b/src/views/docs/en/reference/project-manifest/plugins.md
@@ -6,7 +6,7 @@ description: Extend Architect app functionality and programmatically generate re
 
 Extend the functionality of your Architect app with `@plugins`.
 
-Architect’s plugin API exposes [workflow lifecycle hooks](#workflow-hooks) (such filesystem events in the [Sandbox](/docs/en/reference/cli/sandbox)) and interfaces for [generating cloud resources](#resource-setters) (such as custom Lambdas, or environment variables).
+Architect’s plugin API exposes [workflow lifecycle hooks](/docs/en/guides/plugins/overview#workflow-hooks) (such filesystem events in the [Sandbox](/docs/en/reference/cli/sandbox)) and interfaces for [generating cloud resources](/docs/en/guides/plugins/overview#resource-setters) (such as custom Lambdas, or environment variables).
 
 Plugins can also be used to [customize your AWS deployment via CloudFormation](../../guides/developer-experience/custom-cloudformation), enabling access to cloud resources outside of Architect's built-ins.
 


### PR DESCRIPTION
Initial `#` links on the`@plugins` Project Manifest page where pointing to the current page instead of the intended Plugins Overview page.

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [x] Forked the repo and created your branch from `main`
- [x] Made sure tests pass (run `npm it` from the repo root)
- [x] Updated relevant documentation internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
- [x] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA as it's required for your PR to be merged. A github comment will prompt you if you haven't already.

Learn more about [contributing to Architect here](/docs/en/about/contribute).

Thanks again!
