### PR TITLE
Bump acceptable npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "Apache-2.0",
   "engines": {
     "node": ">=16.14.0",
-    "npm": ">=8.5.0 <9"
+    "npm": ">=8.5.0"
   },
   "scripts": {
     "spellcheck": "npx spellchecker --config ./scripts/spellcheckerrc.json",


### PR DESCRIPTION
Our build wasn't working because our GitHub action is setup to use Node LTS. As of Feb 1st, 2023 the LTS version of Node uses npm 9.3.1 or greater. Our package.json was set to use npm 8.5.0 or later and npm less than 9.0.0. This commit changes the package.json to allow npm 9.