### PR TITLE
Update defaults for Node.js versions and architecture

### DIFF
--- a/src/views/docs/en/reference/configuration/function-config.md
+++ b/src/views/docs/en/reference/configuration/function-config.md
@@ -44,7 +44,7 @@ Configure the deployed function with [the `@aws` pragma](../project-manifest/aws
 - [`provisionedConcurrency`](#provisionedconcurrency) - number, `1` to AWS account maximum (disabled by default)
 - [`layers`](#layers) - Up to 5 Lambda layer ARNs; **must be in the same region as deployed**
 - [`policies`](#policies) - Configure [AWS SAM policy templates](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)
-- [`architecture`](#architecture) - [AWS Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) for the function: `arm64` (default) or `x86_64`
+- [`architecture`](#architecture) - [AWS Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) for the function: `x86_64` (default) or `arm64`
 - [`storage`](#storage) - number, between `512` (default) and `10240` MB. The function's ephemeral storage (`/tmp` file system).
 - [`fifo`](#fifo) - boolean, `true` (default) or `false` to use `standard` SQS type
 

--- a/src/views/docs/en/reference/configuration/function-config.md
+++ b/src/views/docs/en/reference/configuration/function-config.md
@@ -37,14 +37,14 @@ views false
 
 Configure the deployed function with [the `@aws` pragma](../project-manifest/aws) and the following properties:
 
-- [`runtime`](#runtime) - string, Lambda runtime or alias: `nodejs14.x` (default), `python3.7`, `dotnetcore3.1`, `node`, `py`, `.net`, etc.
+- [`runtime`](#runtime) - string, Lambda runtime or alias: `nodejs16.x` (default), `python3.7`, `dotnetcore3.1`, `node`, `py`, `.net`, etc.
 - [`memory`](#memory) - number, between `128` and `3008` MB in 64 MB increments.
 - [`timeout`](#timeout) - number, in seconds (max `900`)
 - [`concurrency`](#concurrency) - number, `0` to AWS account maximum (if not present, concurrency is unthrottled)
 - [`provisionedConcurrency`](#provisionedconcurrency) - number, `1` to AWS account maximum (disabled by default)
 - [`layers`](#layers) - Up to 5 Lambda layer ARNs; **must be in the same region as deployed**
 - [`policies`](#policies) - Configure [AWS SAM policy templates](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-templates.html)
-- [`architecture`](#architecture) - [AWS Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) for the function: `x86_64` (default) or `arm64`
+- [`architecture`](#architecture) - [AWS Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) for the function: `arm64` (default) or `x86_64`
 - [`storage`](#storage) - number, between `512` (default) and `10240` MB. The function's ephemeral storage (`/tmp` file system).
 - [`fifo`](#fifo) - boolean, `true` (default) or `false` to use `standard` SQS type
 
@@ -70,7 +70,7 @@ architecture arm64
 
 Configure Lambda function `runtime`:
 
-- Like `nodejs14.x` (default), `nodejs16.x`, `python3.9`, `ruby2.7`
+- Like `nodejs16.x` (default), `nodejs14.x`, `python3.9`, `ruby2.7`
 - Unsupported by Sandbox locally: `dotnetcore3.1`, `go1.x`, `java11`
 - Or a runtime alias: `nodejs`, `python`, `ruby`, `.net`, `go`,  `java`
   - Aliases always use the default version of the matched runtime: `ruby` => `ruby2.7`.

--- a/src/views/docs/en/reference/project-manifest/aws.md
+++ b/src/views/docs/en/reference/project-manifest/aws.md
@@ -59,8 +59,8 @@ Configure Lambda function `layers` with max 5 Lambda Layer ARNs. Lambda Layers m
 ### `architecture`
 
 Lambda [CPU Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) of your functions.
-  - `arm64` (default) - (only available in certain AWS regions) 64-bit ARM architecture
-  - `x86_64` - 64-bit x86 architecture
+  - `x86_64` (default) - 64-bit x86 architecture
+  - `arm64` - (only available in certain AWS regions) 64-bit ARM architecture
 
 ### `storage`
 

--- a/src/views/docs/en/reference/project-manifest/aws.md
+++ b/src/views/docs/en/reference/project-manifest/aws.md
@@ -27,7 +27,7 @@ Local AWS profile name to use with this project, as defined in your [local AWS c
 
 | Runtime | Versions                   | Example            | Alias<sup>1</sup>         |
 |---------|----------------------------|--------------------|---------------------------|
-| Node.js | 12.x, 14.x (default), 16.x | `nodejs16.x`       | `node` `nodejs` `node.js` |
+| Node.js | 12.x, 14.x, 16.x (default) | `nodejs16.x`       | `node` `nodejs` `node.js` |
 | Python  | 3.6 - 3.9                  | `python3.9`        | `python` `py`             |
 | Ruby    | 2.7                        | `ruby2.7`          | `ruby` `rb`               |
 | .NET    | 3.1                        | `dotnetcore3.1`    | `dotnet` `.net`           |
@@ -59,8 +59,8 @@ Configure Lambda function `layers` with max 5 Lambda Layer ARNs. Lambda Layers m
 ### `architecture`
 
 Lambda [CPU Architecture](https://docs.aws.amazon.com/lambda/latest/dg/foundation-arch.html) of your functions.
-  - `x86_64` (default) - 64-bit x86 architecture
-  - `arm64` - (only available in certain AWS regions) 64-bit ARM architecture
+  - `arm64` (default) - (only available in certain AWS regions) 64-bit ARM architecture
+  - `x86_64` - 64-bit x86 architecture
 
 ### `storage`
 


### PR DESCRIPTION
Noticed 14.x and x86 are mentioned as defaults still in the documentation. Creating a fresh project and deployed to confirm it should be 16.x and arm64 and updated all the references I could find.

Not sure if 18.x should be worked in some of these references too, but felt that veered more in to stylistic that basic correction at this stage.