### PR TITLE
Add Node 20 as a runtime option in AWS

### DIFF
--- a/src/views/docs/en/reference/project-manifest/aws.md
+++ b/src/views/docs/en/reference/project-manifest/aws.md
@@ -29,7 +29,7 @@ Local AWS profile name to use with this project, as defined in your [local AWS c
 
 | Runtime | Versions                            | Example       | Alias<sup>1</sup>         |
 |---------|-------------------------------------|---------------|---------------------------|
-| Node.js | 14.x, 16.x (default), 18.x          | `nodejs16.x`  | `node` `nodejs` `node.js` |
+| Node.js | 14.x, 16.x (default), 18.x, 20.x    | `nodejs16.x`  | `node` `nodejs` `node.js` |
 | Python  | 3.7, 3.8, 3.9 (default), 3.10, 3.11 | `python3.9`   | `python` `py`             |
 | Ruby    | 2.7 (default). 3.2                  | `ruby2.7`     | `ruby` `rb`               |
 | .NET    | 6 (default), 7                      | `dotnet6`     | `dotnet` `.net`           |


### PR DESCRIPTION
Ref: https://aws.amazon.com/blogs/compute/node-js-20-x-runtime-now-available-in-aws-lambda/

I was researching the support for AWS Lambda Node 20 and decided to make a small update to the AWS `runtime` section of the Project Manifest documentation since I was already checking when the support will be available for Architect.