### PR TITLE
Mention removal of built-in API Gateway REST support

### DIFF
--- a/src/views/docs/en/about/upgrade-guide.md
+++ b/src/views/docs/en/about/upgrade-guide.md
@@ -96,6 +96,7 @@ Most of Architect 10's breaking changes were internal; most users should not enc
 - Removed support for legacy `.arc-env` env files (initially deprecated in late 2020)
   - Remedy: if you are still using a `.arc-env` file, please move your [local env vars to `prefs.arc`](https://arc.codes/docs/en/reference/configuration/local-preferences#%40env) or [`.env`](https://arc.codes/docs/en/reference/configuration/local-preferences#.env-file-support)
 - [Removed `toml` support](https://github.com/architect/architect/discussions/1294) (e.g. `arc.toml`)
+- Removed built-in support for the `REST` API Gateway. Support is moved to an external plugin, [plugin-rest-api](https://github.com/architect/plugin-rest-api).
 
 
 ### Breaking changes

--- a/src/views/docs/en/reference/project-manifest/aws.md
+++ b/src/views/docs/en/reference/project-manifest/aws.md
@@ -80,7 +80,7 @@ API Gateway API type, can be one of:
 - `http` (default) - `HTTP` API + Lambda payload format version 2.0
 - `httpv2` – alias of `http`
 - `httpv1` - `HTTP` API + Lambda payload format version 1.0 (aka `REST`)
-- `rest` - `REST` API + original API Gateway payload format
+- `rest` - `REST` API + original API Gateway payload format (note: only supported when using the [plugin-rest-api](https://github.com/architect/plugin-rest-api) plugin)
 
 
 ## Environment Variables


### PR DESCRIPTION
As per my comment on [this issue](https://github.com/architect/architect/issues/1297#issuecomment-1829933174), I'm adding some documentation that support of the REST API type in API Gateway has been moved to a plugin.