### PR TITLE
fix `arc create` output in project-manifest docs

### DIFF
--- a/src/views/docs/en/reference/project-manifest/events.md
+++ b/src/views/docs/en/reference/project-manifest/events.md
@@ -82,16 +82,15 @@ events:
 </div>
 </arc-viewer>
 
-Which generates the following scaffolding:
+Running `arc create` generates the following handlers:
 
 ```bash
 /
-├── custom
+├── custom/
 │   └── source/
-├── src
-│   └── events
-│     ├── hit-counter/
-│     └── likes/
+├── src/events/
+│   ├── hit-counter/
+│   └── likes/
 ├── app.arc
 └── package.json
 ```

--- a/src/views/docs/en/reference/project-manifest/http.md
+++ b/src/views/docs/en/reference/project-manifest/http.md
@@ -116,20 +116,19 @@ http:
 </div>
 </arc-viewer>
 
-Which utilizes the following project directory structure:
+Running `arc create` generates the following handlers:
 
 ```bash
 /
-├── custom
+├── custom/
 │   └── source/
-├── src
-│   └── http
-│       ├── get-index/
-│       ├── get-pages/
-│       ├── get-pages-000dateID/
-│       ├── get-contact/
-│       ├── get-widgets-catchall/
-│       └── post-contact/
+├── src/http/
+│   ├── get-index/
+│   ├── get-pages/
+│   ├── get-pages-000dateID/
+│   ├── get-contact/
+│   ├── get-widgets-catchall/
+│   └── post-contact/
 ├── app.arc
 └── package.json
 ```

--- a/src/views/docs/en/reference/project-manifest/proxy.md
+++ b/src/views/docs/en/reference/project-manifest/proxy.md
@@ -79,6 +79,6 @@ proxy:
 </arc-tab>
 
 </div>
-<arc-viewer>
+</arc-viewer>
 
 With the above Architect file, your new app will respond to all get and post requests to `/v2/*`, and forward along requests to `/v1` to your existing API.

--- a/src/views/docs/en/reference/project-manifest/queues.md
+++ b/src/views/docs/en/reference/project-manifest/queues.md
@@ -1,5 +1,5 @@
 ---
-title: '<code>@queues</code>'
+title: "<code>@queues</code>"
 category: app.arc
 description: Define SQS topics
 ---
@@ -12,7 +12,6 @@ Define SQS topics with Lambda handler functions.
 - Maximum of 240 characters
 - Dashes, periods, and underscores are allowed
 - Must begin with a letter
-
 
 ### Example
 
@@ -33,6 +32,7 @@ myapp
 convert-image
 publish-log
 ```
+
 </div>
 </arc-tab>
 
@@ -42,13 +42,11 @@ publish-log
 
 ```json
 {
-  "app": "myapp",
-  "queues": [
-    "convert-image",
-    "publish-log"
-  ]
+	"app": "myapp",
+	"queues": ["convert-image", "publish-log"]
 }
 ```
+
 </div>
 </arc-tab>
 
@@ -60,9 +58,10 @@ publish-log
 ---
 app: myapp
 queues:
-- convert-image
-- publish-log
+  - convert-image
+  - publish-log
 ```
+
 </div>
 </arc-tab>
 
@@ -73,8 +72,10 @@ Which generates the corresponding code:
 
 ```bash
 /
-├── queues
-│   ├── convert-image/
-│   └── publish-log/
-└── app.arc
+├── src
+│   └── queues
+│       ├── convert-image/
+│       └── publish-log/
+├── app.arc
+└── package.json
 ```

--- a/src/views/docs/en/reference/project-manifest/queues.md
+++ b/src/views/docs/en/reference/project-manifest/queues.md
@@ -1,5 +1,5 @@
 ---
-title: "<code>@queues</code>"
+title: '<code>@queues</code>'
 category: app.arc
 description: Define SQS topics
 ---
@@ -42,8 +42,11 @@ publish-log
 
 ```json
 {
-	"app": "myapp",
-	"queues": ["convert-image", "publish-log"]
+  "app": "myapp",
+  "queues": [
+    "convert-image",
+    "publish-log"
+  ]
 }
 ```
 
@@ -58,8 +61,8 @@ publish-log
 ---
 app: myapp
 queues:
-  - convert-image
-  - publish-log
+- convert-image
+- publish-log
 ```
 
 </div>
@@ -68,14 +71,13 @@ queues:
 </div>
 </arc-viewer>
 
-Which generates the corresponding code:
+Running `arc create` generates the following handlers:
 
 ```bash
 /
-├── src
-│   └── queues
-│       ├── convert-image/
-│       └── publish-log/
+├── src/queues/
+│   ├── convert-image/
+│   └── publish-log/
 ├── app.arc
 └── package.json
 ```

--- a/src/views/docs/en/reference/project-manifest/queues.md
+++ b/src/views/docs/en/reference/project-manifest/queues.md
@@ -67,7 +67,7 @@ queues:
 </arc-tab>
 
 </div>
-<arc-viewer>
+</arc-viewer>
 
 Which generates the corresponding code:
 

--- a/src/views/docs/en/reference/project-manifest/scheduled.md
+++ b/src/views/docs/en/reference/project-manifest/scheduled.md
@@ -87,17 +87,14 @@ scheduled:
 </div>
 </arc-viewer>
 
-
-Which generates the following scaffolding:
+Running `arc create` generates the following handlers:
 
 ```bash
 /
-├── custom
-│   └── source/
-├── src/
-│   └── scheduled/
-│       ├── daily-update-buddy/
-│       └── friyay-only/
+├── custom/source/
+├── src/scheduled/
+│   ├── daily-update-buddy/
+│   └── friyay-only/
 ├── app.arc
 └── package.json
 ```

--- a/src/views/docs/en/reference/project-manifest/ws.md
+++ b/src/views/docs/en/reference/project-manifest/ws.md
@@ -68,7 +68,7 @@ Running `arc create` generates the following WebSocket handlers, each mapping to
 
 ```bash
 /
-├── src/ws
+├── src/ws/
 │   ├── connect
 │   ├── default
 │   └── disconnect


### PR DESCRIPTION
Firstly there were a couple of <arc-viewer> elements that needed closed (spotted by @ryanblock)

Second, the directory outputs were a little off, and inconsistent.

Finally, I felt like it needed to be explicit that the scaffolding is only generated when `arc create` is run.