### PR TITLE
fix: wrong import syntax used in python examples

### DIFF
--- a/src/views/docs/en/guides/developer-experience/dependency-management.md
+++ b/src/views/docs/en/guides/developer-experience/dependency-management.md
@@ -166,17 +166,17 @@ To share code across multiple Lambdas, please make use of `@shared` and `@views`
 For example, assume the following `src/http/get-index/lambda.py` handler:
 
 ```python
-# This is ok if it exists in the root requirements.txt file
+# This is ok if it exists in the `requirements.txt` file
 import arc # → architect-functions
 
 # This will fail
-import ..foo
+from ..foo import bar
 
-# This will work (if present, of course)
-import .foo
+# This will work (assuming `foo.py` exists in the same directory, of course)
+from foo import bar
 
-# This is also ok (if foo exists in @shared)
-import vendor.shared.foo
+# This is also ok (if `foo.py` exists in @shared)
+from vendor.shared.foo import bar
 ```
 
 ---

--- a/src/views/docs/en/guides/developer-experience/sharing-code.md
+++ b/src/views/docs/en/guides/developer-experience/sharing-code.md
@@ -84,8 +84,8 @@ require_relative './vendor/views/document'
 
 ```python
 # get-index/lambda.py
-import vendor.shared.authenticate
-import vendor.views.document
+from vendor.shared.authenticate import foo
+from vendor.views.document import bar
 ```
 
 </div>
@@ -129,7 +129,7 @@ require_relative './vendor/shared/authenticate'
 
 ```python
 # post-like/lambda.py
-import vendor.shared.authenticate
+from vendor.shared.authenticate import foo
 ```
 
 </div>
@@ -190,8 +190,8 @@ require_relative './vendor/views/document'
 
 ```python
 # get-index/lambda.py
-import vendor.shared.authenticate
-import vendor.views.document
+from vendor.shared.authenticate import foo
+from vendor.views.document import bar
 ```
 
 </div>


### PR DESCRIPTION
relates to architect/architect#1462

tested out in sandbox, at least